### PR TITLE
Fix ability icons display and implement duplicate feeding system

### DIFF
--- a/characters.html
+++ b/characters.html
@@ -49,7 +49,7 @@
               </div>
               <div class="growth-buttons">
                 <button class="btn-darkgold" id="btn-levelup">Level Up</button>
-                <button class="btn-dark" id="btn-addcopy">Add Copy</button>
+                <button class="btn-dark" id="btn-feeddupe">Feed Duplicate</button>
                 <button class="btn-dark" id="btn-removecopy">Remove Copy</button>
                 <button class="btn-awaken" id="btn-awaken" disabled>Awaken</button>
                 <button class="btn-limitbreak" id="btn-limitbreak" disabled>Limit Break</button>

--- a/css/characters_abilities.css
+++ b/css/characters_abilities.css
@@ -6,30 +6,30 @@
 /* Main Icon Container - Right Side Placement */
 .passive-icons-right {
   position: absolute;
-  right: 20px;
+  right: 15px;
   top: 50%;
   transform: translateY(-50%);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
   z-index: 15;
   pointer-events: none;
   animation: fadeInRight 0.4s ease-out;
 }
 
-/* Individual Icon Container */
+/* Individual Icon Container - Small and Non-Intrusive */
 .passive-icon {
   position: relative;
-  width: 52px;
-  height: 52px;
+  width: 32px;
+  height: 32px;
   background: linear-gradient(135deg, rgba(0, 0, 0, 0.85), rgba(20, 20, 20, 0.75));
   border: 2px solid rgba(255, 200, 0, 0.5);
-  border-radius: 10px;
-  padding: 6px;
+  border-radius: 8px;
+  padding: 4px;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 
+  box-shadow:
     0 4px 12px rgba(0, 0, 0, 0.7),
     inset 0 1px 3px rgba(255, 255, 255, 0.1),
     0 0 0 1px rgba(0, 0, 0, 0.5);

--- a/data/characters.json
+++ b/data/characters.json
@@ -23,6 +23,11 @@
     "growthCurve": { "hp": 1.12, "atk": 1.18, "def": 1.08, "speed": 1.05, "chakra": 1.00 },
     "powerRank": 260,
     "powerWeights": { "hp": 0.35, "atk": 0.35, "def": 0.15, "speed": 0.10, "chakra": 0.05 },
+    "passiveIcons": {
+      "3S": ["hp_up", "heal_up"],
+      "4S": ["hp_up", "heal_up", "atk_up"],
+      "5S": ["hp_up", "heal_up", "atk_up", "def_up"]
+    },
     "abilities": [
       {
         "name": "Never Give Up",
@@ -67,6 +72,11 @@
     "growthCurve": { "hp": 1.10, "atk": 1.22, "def": 1.05, "speed": 1.10, "chakra": 1.00 },
     "powerRank": 280,
     "powerWeights": { "hp": 0.25, "atk": 0.45, "def": 0.10, "speed": 0.15, "chakra": 0.05 },
+    "passiveIcons": {
+      "3S": ["atk_up", "speed_up"],
+      "4S": ["atk_up", "speed_up", "crit_up"],
+      "5S": ["atk_up", "speed_up", "crit_up", "pierce"]
+    },
     "abilities": [
       {
         "name": "Sharingan Awakening",
@@ -103,6 +113,10 @@
     "growthCurve": { "hp": 1.08, "atk": 1.06, "def": 1.12, "speed": 1.02, "chakra": 1.00 },
     "powerRank": 240,
     "powerWeights": { "hp": 0.40, "atk": 0.15, "def": 0.25, "speed": 0.07, "chakra": 0.13 },
+    "passiveIcons": {
+      "3S": ["heal_up", "def_up"],
+      "4S": ["heal_up", "heal_up", "def_up", "hp_up"]
+    },
     "abilities": [
       {
         "name": "Medical Ninjutsu",


### PR DESCRIPTION
- Add passiveIcons data to character JSON (Naruto, Sasuke, Sakura)
  - Icons now display on the right side of character full art
  - Small size (32px) to avoid covering character images

- Replace 'Add Copy' testing button with 'Feed Duplicate' system
  - Uses existing duplicates from inventory
  - Shows selection dialog with all available duplicates
  - Allows feeding dupes to any character version
  - 1 duplicate fed = 1 ability unlocked
  - Fed duplicates are removed from inventory

- Visual locked/unlocked indicators for abilities
  - Already present in dupe abilities system (left side)
  - Shows unlock progress (e.g., "2/4 Unlocked")

- Store current character UID in modal dataset
  - Allows abilities systems to access character data