### PR TITLE
Add gray overlay to locked abilities and darker royal gold badge borders

### DIFF
--- a/css/character_dupe_abilities.css
+++ b/css/character_dupe_abilities.css
@@ -96,6 +96,20 @@
   border-color: rgba(80, 80, 80, 0.5);
   background: linear-gradient(135deg, rgba(10, 10, 10, 0.85), rgba(25, 25, 25, 0.82));
   opacity: 0.7;
+  position: relative;
+}
+
+.ability-item.locked::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(128, 128, 128, 0.5);
+  border-radius: 10px;
+  pointer-events: none;
+  backdrop-filter: grayscale(100%);
 }
 
 .ability-item.locked:hover {
@@ -112,7 +126,7 @@
   width: 36px;
   height: 36px;
   background: linear-gradient(135deg, rgba(218, 165, 32, 0.9), rgba(184, 134, 11, 0.85));
-  border: 2px solid rgba(255, 215, 0, 0.4);
+  border: 2px solid rgba(139, 117, 0, 0.8);
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -128,13 +142,15 @@
 
 .ability-item.unlocked .ability-badge {
   background: linear-gradient(135deg, rgba(255, 215, 0, 0.9), rgba(218, 165, 32, 0.85));
-  border-color: rgba(255, 223, 0, 0.6);
+  border-color: rgba(139, 117, 0, 0.9);
 }
 
 .ability-item.locked .ability-badge {
   background: linear-gradient(135deg, rgba(60, 60, 60, 0.8), rgba(40, 40, 40, 0.75));
   border-color: rgba(100, 100, 100, 0.3);
   color: #888888;
+  position: relative;
+  z-index: 1;
 }
 
 /* Ability Content */
@@ -143,6 +159,8 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
+  position: relative;
+  z-index: 1;
 }
 
 .ability-name {
@@ -168,6 +186,8 @@
   align-items: center;
   gap: 10px;
   padding: 4px 0;
+  position: relative;
+  z-index: 1;
 }
 
 .locked-icon {
@@ -196,6 +216,7 @@
   align-items: center;
   justify-content: center;
   font-size: 12px;
+  z-index: 1;
 }
 
 .ability-status.unlocked {


### PR DESCRIPTION
- Add gray overlay (::after pseudo-element) on locked abilities
- Remove overlay when ability is unlocked
- Change badge borders to darker royal gold (rgba(139, 117, 0))
- Ensure content displays above overlay with z-index positioning