### PR TITLE
Fix stat scaling beyond level 100 and add red text for limit break le…

### DIFF
--- a/js/characters.js
+++ b/js/characters.js
@@ -225,7 +225,16 @@
     // Compute stats (with limit break if applicable)
     let stats = {};
     if (hasProg && window.Progression.computeEffectiveStatsLoreTier) {
-      const comp = window.Progression.computeEffectiveStatsLoreTier(c, safeNum(inst.level,1), tier, { normalize:true });
+      // Calculate extended cap if limit breaks are present
+      let extendedCap = null;
+      if (hasLimitBreak && inst.limitBreakLevel && inst.limitBreakLevel > 0) {
+        extendedCap = window.LimitBreak.getExtendedLevelCap(tier, inst.limitBreakLevel);
+      }
+
+      const comp = window.Progression.computeEffectiveStatsLoreTier(c, safeNum(inst.level,1), tier, {
+        normalize: true,
+        extendedCap: extendedCap
+      });
       stats = comp?.stats || {};
 
       // Apply limit break bonuses if present
@@ -259,7 +268,17 @@
     const level = Math.max(1, safeNum(inst.level, 1));
     const isMax = level >= cap;
 
-    LV_VALUE_EL.textContent = isMax ? "MAX" : String(level);
+    // Update level display with red color when level > 100 or at MAX (150)
+    if (level >= 150) {
+      LV_VALUE_EL.textContent = "MAX";
+      LV_VALUE_EL.style.color = "#DC143C"; // Dark red (crimson)
+    } else if (level > 100) {
+      LV_VALUE_EL.textContent = String(level);
+      LV_VALUE_EL.style.color = "#DC143C"; // Dark red (crimson)
+    } else {
+      LV_VALUE_EL.textContent = isMax ? "MAX" : String(level);
+      LV_VALUE_EL.style.color = ""; // Reset to default
+    }
     LV_CAP_EL.textContent   = String(cap);
 
     // Awakening check

--- a/js/progression.js
+++ b/js/progression.js
@@ -130,8 +130,9 @@
    *  - statsMax  (LvCap at max tierCode)
    *  - growthCurve (number or per-stat object)
    *  - powerRank + powerWeights (optional lore normalization)
+   *  - extendedCap: optional parameter for limit break extended cap
    * ========================================== */
-  function computeEffectiveStatsLoreTier(c, level, tierCode, { normalize = true } = {}) {
+  function computeEffectiveStatsLoreTier(c, level, tierCode, { normalize = true, extendedCap = null } = {}) {
     const { minCode, maxCode } = getTierBounds(c);
     const tier = validCode(tierCode) || minCode;
 
@@ -141,7 +142,8 @@
     const iMax = idxOf(maxCode);
     const clampedTier = TIER_ORDER[clamp(i, iMin, iMax)];
 
-    const cap = levelCapForCode(clampedTier);
+    const baseCap = levelCapForCode(clampedTier);
+    const cap = extendedCap || baseCap; // Use extended cap if provided (for limit breaks)
     const base = c?.statsBase || c?.stats || {};
     const max  = c?.statsMax  || null;
     const gc   = c?.growthCurve;


### PR DESCRIPTION
…vels

- Update computeEffectiveStatsLoreTier to accept extendedCap parameter
- Pass extended cap when computing stats for limit broken characters
- Stats now properly scale from level 100 to 150 with limit breaks
- Level display shows dark red (crimson) text when level > 100
- Level display shows 'MAX' in red when level reaches 150
- Levels 101-149 show the number in red text