### PR TITLE
Fix red text display for limit break levels using CSS classes

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -241,6 +241,8 @@ body.page-characters {
 }
 .level-badge .lv { margin-right: 3px; color: #fff; }
 .level-badge .max { color: var(--gold); font-weight: 600; }
+.level-badge .limit-break { color: #DC143C !important; font-weight: 600; }
+.level-badge .limit-break-max { color: #DC143C !important; font-weight: 700; }
 
 .growth-buttons {
   display: flex;

--- a/js/characters.js
+++ b/js/characters.js
@@ -269,15 +269,20 @@
     const isMax = level >= cap;
 
     // Update level display with red color when level > 100 or at MAX (150)
+    // Remove any existing special classes first
+    LV_VALUE_EL.classList.remove('limit-break', 'limit-break-max', 'max');
+
     if (level >= 150) {
       LV_VALUE_EL.textContent = "MAX";
-      LV_VALUE_EL.style.color = "#DC143C"; // Dark red (crimson)
+      LV_VALUE_EL.classList.add('limit-break-max');
     } else if (level > 100) {
       LV_VALUE_EL.textContent = String(level);
-      LV_VALUE_EL.style.color = "#DC143C"; // Dark red (crimson)
+      LV_VALUE_EL.classList.add('limit-break');
+    } else if (isMax) {
+      LV_VALUE_EL.textContent = "MAX";
+      LV_VALUE_EL.classList.add('max');
     } else {
-      LV_VALUE_EL.textContent = isMax ? "MAX" : String(level);
-      LV_VALUE_EL.style.color = ""; // Reset to default
+      LV_VALUE_EL.textContent = String(level);
     }
     LV_CAP_EL.textContent   = String(cap);
 


### PR DESCRIPTION
- Add limit-break and limit-break-max CSS classes for proper styling
- Use !important to ensure red color overrides default gold styling
- Properly show level 101-149 in red text
- Show 'MAX' in red when level reaches 150
- Fix issue where inline styles were being overridden by CSS