### PR TITLE
Add red text for limit break levels on character grid portraits

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -87,6 +87,16 @@ body.page-characters {
   font-weight: 600;
   letter-spacing: .4px;
 }
+.char-card-level .limit-break {
+  color: #DC143C !important;
+  font-weight: 600;
+  letter-spacing: .4px;
+}
+.char-card-level .limit-break-max {
+  color: #DC143C !important;
+  font-weight: 700;
+  letter-spacing: .4px;
+}
 
 /* ---------- Modal Overlay ---------- */
 #char-modal {

--- a/js/characters.js
+++ b/js/characters.js
@@ -96,13 +96,27 @@
 
   /* ---------- Level badge (grid cards) ---------- */
   function levelBadgeHTML(c, inst) {
-    const t   = inst.tierCode || minTier(c);
-    const cap = tierCap(c, t);
-    const lv  = safeNum(inst.level, 1);
+    const t = inst.tierCode || minTier(c);
+    let cap = tierCap(c, t);
+
+    // Apply extended level cap from limit breaks
+    if (hasLimitBreak && inst.limitBreakLevel && inst.limitBreakLevel > 0) {
+      cap = window.LimitBreak.getExtendedLevelCap(t, inst.limitBreakLevel);
+    }
+
+    const lv = safeNum(inst.level, 1);
     const isMax = lv >= cap;
-    return isMax
-      ? `<span class="lv">Lv</span> <span class="max">MAX</span>`
-      : `<span class="lv">Lv</span> ${lv}`;
+
+    // Handle limit break levels (> 100)
+    if (lv >= 150) {
+      return `<span class="lv">Lv</span> <span class="limit-break-max">MAX</span>`;
+    } else if (lv > 100) {
+      return `<span class="lv">Lv</span> <span class="limit-break">${lv}</span>`;
+    } else if (isMax) {
+      return `<span class="lv">Lv</span> <span class="max">MAX</span>`;
+    } else {
+      return `<span class="lv">Lv</span> ${lv}`;
+    }
   }
 
   /* ---------- Data ---------- */


### PR DESCRIPTION
- Update levelBadgeHTML to check for limit break levels
- Show red text for levels 101-149 on character cards
- Show 'MAX' in red when level reaches 150 on character cards
- Apply extended cap when calculating isMax for limit broken characters
- Add CSS classes for character grid card level badges