### PR TITLE
Fix character portrait sizing issue

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -211,48 +211,51 @@ html, body.page-battle {
 /* === CHARACTER PORTRAITS (SMALLER & PERFECTLY CENTERED) === */
 .unit-card,
 .unit-wrapper {
-  position: absolute !important;
-  display: flex !important;
-  flex-direction: column !important;
-  align-items: center !important;
-  justify-content: center !important;
-  width: 80px !important;
-  height: 100px !important;
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 70px;
+  height: 70px;
+  transform: translate(-50%, -50%);
+  pointer-events: auto;
 }
 
 .unit-portrait,
-#battlefield-grid img,
 .unit-card img {
-  width: 70px !important;
-  height: 70px !important;
-  min-width: 70px !important;
-  min-height: 70px !important;
-  max-width: 70px !important;
-  max-height: 70px !important;
-  object-fit: contain !important;
-  object-position: center center !important;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
   border-radius: 8px;
   image-rendering: crisp-edges;
-  display: block !important;
-  margin: 0 auto !important;
-  position: relative !important;
-  left: 50% !important;
-  top: 50% !important;
-  transform: translate(-50%, -50%) !important;
+  display: block;
+  border: 2px solid rgba(217, 179, 98, 0.6);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+}
+
+.unit-card.player img {
+  border-color: #58b7ff;
+}
+
+.unit-card.enemy img {
+  border-color: #ff4d4d;
 }
 
 .unit-large {
-  width: 90px !important;
-  height: 90px !important;
-  min-width: 90px !important;
-  min-height: 90px !important;
-  max-width: 90px !important;
-  max-height: 90px !important;
+  width: 90px;
+  height: 90px;
 }
 
 /* === Prevent Any Weird Positioning === */
 .unit-card {
-  overflow: visible !important;
+  overflow: visible;
+  cursor: grab;
+}
+
+.unit-card:active {
+  cursor: grabbing;
 }
 
 /* === Bench Units === */

--- a/js/battle/battle-physics.js
+++ b/js/battle/battle-physics.js
@@ -105,6 +105,7 @@
           const wobble = Math.sin(progress * Math.PI * 4) * 3 * (1 - progress);
           unitEl.style.transform = `translate(-50%, -50%) rotate(${wobble}deg)`;
         } else {
+          // Reset to base transform
           unitEl.style.transform = 'translate(-50%, -50%)';
         }
 


### PR DESCRIPTION
The unit portraits were super-sized and blocking the screen due to conflicting CSS rules. Fixed by:

- Removed conflicting transform rules on images
- Set unit-card container to proper size (70px x 70px)
- Kept transform: translate(-50%, -50%) on container only
- Images now fill container at 100% width/height
- Added proper borders and shadows
- Added player/enemy color distinctions
- Maintained knockback physics compatibility

Files modified:
- css/battle.css: Fixed unit-card and portrait sizing
- js/battle/battle-physics.js: Added comment for clarity