### PR TITLE
Fix unit sizing conflicts between CSS files

### DIFF
--- a/css/battle-ui-fixes.css
+++ b/css/battle-ui-fixes.css
@@ -198,18 +198,25 @@
 /* Unit Container - Ensure proper stacking */
 .battle-unit {
   position: absolute;
-  width: 64px;
-  height: 80px; /* Increased to accommodate bars */
+  width: 70px;
+  height: 70px;
   display: flex;
   flex-direction: column;
   align-items: center;
   z-index: 1;
+  transform: translate(-50%, -50%);
+  pointer-events: auto;
+  cursor: grab;
+}
+
+.battle-unit:active {
+  cursor: grabbing;
 }
 
 /* Unit Sprite Container */
 .unit-sprite {
-  width: 64px;
-  height: 64px;
+  width: 70px;
+  height: 70px;
   position: relative;
   border-radius: 8px;
   overflow: hidden;
@@ -226,14 +233,16 @@
 
 /* HP Bar Container - BELOW sprite */
 .unit-hp-bar {
-  position: relative;
-  width: 58px;
+  position: absolute;
+  bottom: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 64px;
   height: 6px;
   background: rgba(0, 0, 0, 0.8);
   border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 3px;
   overflow: hidden;
-  margin-top: 2px;
   z-index: 1;
 }
 
@@ -263,14 +272,16 @@
 
 /* Chakra Bar - BELOW HP bar */
 .unit-chakra-bar {
-  position: relative;
-  width: 58px;
+  position: absolute;
+  bottom: -18px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 64px;
   height: 4px;
   background: rgba(0, 0, 0, 0.8);
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 2px;
   overflow: hidden;
-  margin-top: 1px;
   z-index: 1;
 }
 
@@ -433,18 +444,18 @@
 
 @media (max-width: 768px) {
   .battle-unit {
-    width: 48px;
-    height: 64px;
+    width: 60px;
+    height: 60px;
   }
 
   .unit-sprite {
-    width: 48px;
-    height: 48px;
+    width: 60px;
+    height: 60px;
   }
 
   .unit-hp-bar,
   .unit-chakra-bar {
-    width: 44px;
+    width: 54px;
   }
 
   #action-panel button {

--- a/css/battle.css
+++ b/css/battle.css
@@ -208,54 +208,16 @@ html, body.page-battle {
   pointer-events: none;
 }
 
-/* === CHARACTER PORTRAITS (SMALLER & PERFECTLY CENTERED) === */
-.unit-card,
-.unit-wrapper {
-  position: absolute;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 70px;
-  height: 70px;
-  transform: translate(-50%, -50%);
-  pointer-events: auto;
+/* === CHARACTER PORTRAITS === */
+/* Note: Actual unit styling is in battle-ui-fixes.css using .battle-unit class */
+
+/* Additional borders for player/enemy distinction */
+.battle-unit.player .unit-sprite {
+  border: 2px solid #58b7ff;
 }
 
-.unit-portrait,
-.unit-card img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: center;
-  border-radius: 8px;
-  image-rendering: crisp-edges;
-  display: block;
-  border: 2px solid rgba(217, 179, 98, 0.6);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
-}
-
-.unit-card.player img {
-  border-color: #58b7ff;
-}
-
-.unit-card.enemy img {
-  border-color: #ff4d4d;
-}
-
-.unit-large {
-  width: 90px;
-  height: 90px;
-}
-
-/* === Prevent Any Weird Positioning === */
-.unit-card {
-  overflow: visible;
-  cursor: grab;
-}
-
-.unit-card:active {
-  cursor: grabbing;
+.battle-unit.enemy .unit-sprite {
+  border: 2px solid #ff4d4d;
 }
 
 /* === Bench Units === */


### PR DESCRIPTION
The issue was conflicting styles between battle.css and battle-ui-fixes.css:
- JavaScript uses .battle-unit class (not .unit-card)
- battle-ui-fixes.css had .battle-unit at 64px x 80px
- battle.css was styling .unit-card (which wasn't being used)

Fixed by:
- Updated .battle-unit in battle-ui-fixes.css to 70px x 70px
- Added transform: translate(-50%, -50%) to .battle-unit for proper centering
- Updated HP/Chakra bars to use absolute positioning below sprite
- Removed conflicting .unit-card styles from battle.css
- Added proper player/enemy border colors to .battle-unit .unit-sprite
- Updated responsive sizing for mobile

Files modified:
- css/battle-ui-fixes.css: Fixed .battle-unit sizing and positioning
- css/battle.css: Removed conflicting .unit-card styles