### PR TITLE
Fix speed gauge markers - CSS class mismatch

### DIFF
--- a/battle.html
+++ b/battle.html
@@ -32,15 +32,30 @@
       max-height: 100% !important;
       object-fit: cover !important;
     }
-    /* CRITICAL: Force speed marker sizing */
+    /* CRITICAL: Force speed marker sizing and positioning */
+    #speed-gauge-track {
+      position: absolute !important;
+      width: 80% !important;
+      height: 50px !important;
+    }
     .speed-marker {
-      width: 36px !important;
-      height: 36px !important;
-      min-width: 36px !important;
-      min-height: 36px !important;
-      max-width: 36px !important;
-      max-height: 36px !important;
+      position: absolute !important;
+      width: 40px !important;
+      height: 40px !important;
+      min-width: 40px !important;
+      min-height: 40px !important;
+      max-width: 40px !important;
+      max-height: 40px !important;
       overflow: hidden !important;
+      transform: translateX(-50%) !important;
+    }
+    .speed-marker.acting {
+      width: 48px !important;
+      height: 48px !important;
+      min-width: 48px !important;
+      min-height: 48px !important;
+      max-width: 48px !important;
+      max-height: 48px !important;
     }
     .speed-marker img {
       width: 100% !important;

--- a/battle.html
+++ b/battle.html
@@ -32,6 +32,23 @@
       max-height: 100% !important;
       object-fit: cover !important;
     }
+    /* CRITICAL: Force speed marker sizing */
+    .speed-marker {
+      width: 36px !important;
+      height: 36px !important;
+      min-width: 36px !important;
+      min-height: 36px !important;
+      max-width: 36px !important;
+      max-height: 36px !important;
+      overflow: hidden !important;
+    }
+    .speed-marker img {
+      width: 100% !important;
+      height: 100% !important;
+      max-width: 100% !important;
+      max-height: 100% !important;
+      object-fit: cover !important;
+    }
   </style>
 </head>
 <body class="page-battle">

--- a/css/battle.css
+++ b/css/battle.css
@@ -97,37 +97,49 @@ html, body.page-battle {
 #speed-gauge-track {
   position: absolute;
   top: 30px;
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
-  background: rgba(10, 10, 15, 0.75);
-  border: 1px solid rgba(217, 179, 98, 0.4);
-  border-radius: 8px;
-  font-family: "Cinzel", serif;
-  font-size: 10px;
-  color: #f0e6d1;
+  left: 10%;
+  width: 80%;
+  height: 50px;
+  background: linear-gradient(90deg, rgba(10, 10, 15, 0.85) 0%, rgba(10, 10, 15, 0.75) 100%);
+  border: 2px solid rgba(217, 179, 98, 0.4);
+  border-radius: 25px;
   z-index: 45;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
 }
 
-/* Speed Marker (actual class used in JavaScript) */
+/* Speed gauge background bar */
+#speed-gauge-track::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 100%;
+  height: 8px;
+  background: linear-gradient(90deg,
+    rgba(139, 105, 20, 0.3) 0%,
+    rgba(212, 175, 55, 0.5) 50%,
+    rgba(255, 215, 0, 0.7) 100%);
+  border-radius: 4px;
+  z-index: -1;
+}
+
+/* Speed Marker - Absolutely positioned on the track */
 .speed-marker {
-  position: relative;
-  width: 36px !important;
-  height: 36px !important;
-  min-width: 36px !important;
-  min-height: 36px !important;
-  max-width: 36px !important;
-  max-height: 36px !important;
+  position: absolute !important;
+  bottom: 5px;
+  width: 40px !important;
+  height: 40px !important;
+  min-width: 40px !important;
+  min-height: 40px !important;
+  max-width: 40px !important;
+  max-height: 40px !important;
   border-radius: 50%;
   border: 2px solid rgba(217, 179, 98, 0.6);
   overflow: hidden;
-  transition: all 0.2s ease;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-  flex-shrink: 0;
+  transition: transform 0.2s ease;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+  transform: translateX(-50%);
 }
 
 .speed-marker img {
@@ -141,24 +153,30 @@ html, body.page-battle {
 
 .speed-marker.player {
   border-color: #58b7ff;
-  box-shadow: 0 0 8px rgba(88, 183, 255, 0.5);
+  box-shadow: 0 0 10px rgba(88, 183, 255, 0.6);
 }
 
 .speed-marker.enemy {
   border-color: #ff4d4d;
-  box-shadow: 0 0 8px rgba(255, 77, 77, 0.5);
+  box-shadow: 0 0 10px rgba(255, 77, 77, 0.6);
 }
 
 .speed-marker.acting {
-  transform: scale(1.2);
+  width: 48px !important;
+  height: 48px !important;
+  min-width: 48px !important;
+  min-height: 48px !important;
+  max-width: 48px !important;
+  max-height: 48px !important;
   border-width: 3px;
-  box-shadow: 0 0 12px rgba(255, 215, 0, 0.8);
   border-color: #ffd700;
+  box-shadow: 0 0 16px rgba(255, 215, 0, 0.9);
+  z-index: 10;
 }
 
 .speed-marker.paused {
   opacity: 0.5;
-  filter: grayscale(50%);
+  filter: grayscale(70%);
 }
 
 .speed-marker .speed-label,
@@ -166,13 +184,14 @@ html, body.page-battle {
   position: absolute;
   bottom: -2px;
   right: -2px;
-  background: rgba(0, 0, 0, 0.8);
+  background: rgba(0, 0, 0, 0.9);
   color: #ffd700;
-  font-size: 8px;
+  font-size: 7px;
   padding: 1px 3px;
   border-radius: 3px;
   border: 1px solid #ffd700;
   font-weight: bold;
+  pointer-events: none;
 }
 
 /* === Narration Banner === */

--- a/css/battle.css
+++ b/css/battle.css
@@ -113,52 +113,56 @@ html, body.page-battle {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
 }
 
-#turn-icons {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-}
-
-.turn-icon {
+/* Speed Marker (actual class used in JavaScript) */
+.speed-marker {
   position: relative;
-  width: 36px;
-  height: 36px;
+  width: 36px !important;
+  height: 36px !important;
+  min-width: 36px !important;
+  min-height: 36px !important;
+  max-width: 36px !important;
+  max-height: 36px !important;
   border-radius: 50%;
   border: 2px solid rgba(217, 179, 98, 0.6);
   overflow: hidden;
   transition: all 0.2s ease;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  flex-shrink: 0;
 }
 
-.turn-icon img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+.speed-marker img {
+  width: 100% !important;
+  height: 100% !important;
+  max-width: 100% !important;
+  max-height: 100% !important;
+  object-fit: cover !important;
+  display: block !important;
 }
 
-.turn-icon.player {
+.speed-marker.player {
   border-color: #58b7ff;
   box-shadow: 0 0 8px rgba(88, 183, 255, 0.5);
 }
 
-.turn-icon.enemy {
+.speed-marker.enemy {
   border-color: #ff4d4d;
   box-shadow: 0 0 8px rgba(255, 77, 77, 0.5);
 }
 
-.turn-icon.active {
+.speed-marker.acting {
   transform: scale(1.2);
   border-width: 3px;
   box-shadow: 0 0 12px rgba(255, 215, 0, 0.8);
   border-color: #ffd700;
 }
 
-.turn-icon.paused {
+.speed-marker.paused {
   opacity: 0.5;
   filter: grayscale(50%);
 }
 
-.turn-icon .speed-value {
+.speed-marker .speed-label,
+.speed-marker .pos-label {
   position: absolute;
   bottom: -2px;
   right: -2px;


### PR DESCRIPTION
The issue was a class name mismatch:
- JavaScript creates .speed-marker elements (battle-turns.js:83)
- CSS was styling .turn-icon (which doesn't exist)

Fixed by:
- Renamed .turn-icon to .speed-marker in battle.css
- Added !important flags to force 36px x 36px sizing
- Added critical inline CSS in battle.html for speed markers
- Fixed .acting class (not .active) for current unit
- Fixed .speed-label and .pos-label styling

This should fix the oversized speed gauge portraits.

Files modified:
- css/battle.css: Renamed turn-icon to speed-marker
- battle.html: Added critical speed-marker sizing