### PR TITLE
Disable speed gauge temporarily - causing display issues

### DIFF
--- a/battle.html
+++ b/battle.html
@@ -34,9 +34,10 @@
     }
     /* CRITICAL: Force speed marker sizing and positioning */
     #speed-gauge-track {
-      position: absolute !important;
-      width: 80% !important;
-      height: 50px !important;
+      display: none !important;
+      visibility: hidden !important;
+      opacity: 0 !important;
+      pointer-events: none !important;
     }
     .speed-marker {
       position: absolute !important;


### PR DESCRIPTION
The speed gauge was taking up 80% of the screen despite having proper sizing constraints. Hiding it completely for now while we debug the root cause.

Changed #speed-gauge-track to display: none with multiple redundant hiding properties to ensure it's completely invisible.

The combat system (targeting, knockback, proximity combos, damage display) will all still work - just without the speed gauge visual.

Files modified:
- battle.html: Hidden speed gauge track with display: none

TODO: Debug why speed gauge was rendering so large despite CSS constraints