### PR TITLE
Fix team HP bar color and enemy HP display

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -74,7 +74,7 @@ html, body.page-battle {
 
 .hp-fill {
   height: 100%;
-  background: linear-gradient(90deg, #ff8247, #ffd66b, #a6ff70);
+  background: linear-gradient(90deg, #d4af37, #ffd700, #ffed4e);
   transition: width 0.3s ease-in-out;
 }
 

--- a/js/battle/battle-missions.js
+++ b/js/battle/battle-missions.js
@@ -82,7 +82,7 @@
           bm.units.createCombatant({
             ...base,
             isPlayer: false,
-            stats: { ...base.stats },
+            stats: { ...base.stats, maxHP: base.stats.hp },
             pos: { x: 70 + (i % 2 * 15), y: 25 + Math.floor(i / 2) * 25 }
           }) :
           {


### PR DESCRIPTION
- Changed team HP bar fill to gold gradient (#d4af37 -> #ffd700 -> #ffed4e)
- Fixed enemy HP bars not displaying by ensuring maxHP is set when enemies are created
- Enemy stats now include maxHP property to prevent NaN in HP percentage calculation