### PR TITLE
Restore speed gauge visibility

### DIFF
--- a/battle.html
+++ b/battle.html
@@ -32,12 +32,15 @@
       max-height: 100% !important;
       object-fit: cover !important;
     }
-    /* CRITICAL: Force speed marker sizing and positioning */
+    /* CRITICAL: Force speed gauge track sizing */
     #speed-gauge-track {
-      display: none !important;
-      visibility: hidden !important;
-      opacity: 0 !important;
-      pointer-events: none !important;
+      position: absolute !important;
+      top: 30px !important;
+      left: 10% !important;
+      width: 80% !important;
+      height: 50px !important;
+      max-height: 50px !important;
+      overflow: visible !important;
     }
     .speed-marker {
       position: absolute !important;


### PR DESCRIPTION
- Removed display: none from speed-gauge-track which was hiding all speed markers
- Speed markers are children of the track, so hiding parent hides children too
- Now track is properly sized instead of hidden
- Markers should display correctly at 40px x 40px along the gauge