### PR TITLE
Fix HP bar not decreasing for last enemy and increase damage text size

### DIFF
--- a/js/battle/battle-animations.js
+++ b/js/battle/battle-animations.js
@@ -45,7 +45,7 @@
       damageEl.style.top = `${rect.top - sceneRect.top}px`;
       damageEl.style.transform = 'translate(-50%, -100%)';
       damageEl.style.animation = 'damageFloat 1s ease-out forwards';
-      damageEl.style.fontSize = isCritical ? '3rem' : '2.2rem';
+      damageEl.style.fontSize = isCritical ? '4.5rem' : '3.5rem';
       damageEl.style.fontWeight = 'bold';
       damageEl.style.color = isHeal ? '#2ecc71' : (isCritical ? '#ff4444' : '#ffffff');
       damageEl.style.textShadow = '3px 3px 6px rgba(0,0,0,0.9), 0 0 10px rgba(0,0,0,0.5)';

--- a/js/battle/battle-combat.js
+++ b/js/battle/battle-combat.js
@@ -278,7 +278,11 @@
       }
 
       core.updateTeamHP();
-      core.checkBattleEnd();
+
+      // Delay battle end check to allow HP bar animation to complete
+      setTimeout(() => {
+        core.checkBattleEnd();
+      }, 400);
     },
 
     /* ===== Jutsu (Single Target Skill) ===== */
@@ -514,7 +518,10 @@
 
       setTimeout(() => {
         core.updateTeamHP();
-        core.checkBattleEnd();
+        // Delay battle end check to allow HP bar animation to complete
+        setTimeout(() => {
+          core.checkBattleEnd();
+        }, 400);
       }, targets.length * 150 + 300);
     },
 
@@ -580,7 +587,10 @@
 
       setTimeout(() => {
         core.updateTeamHP();
-        core.checkBattleEnd();
+        // Delay battle end check to allow HP bar animation to complete
+        setTimeout(() => {
+          core.checkBattleEnd();
+        }, 400);
       }, targets.length * 120 + 200);
     },
 


### PR DESCRIPTION
- Added 400ms delay before checkBattleEnd() to allow HP bar animations to complete
- Applied fix to performAttack, performMultiAttack, and performProximityCombo
- Now HP bars properly animate down before victory/next wave screen appears
- Increased damage number font size: normal 2.2rem -> 3.5rem, critical 3rem -> 4.5rem
- Damage numbers are now much more visible and impactful