### PR TITLE
Give enemies higher starting speed gauge for turn advantage

### DIFF
--- a/js/battle/battle-missions.js
+++ b/js/battle/battle-missions.js
@@ -103,7 +103,7 @@
             pos: { x: 70 + (i % 2 * 15), y: 25 + Math.floor(i / 2) * 25 },
             chakra: 0,
             maxChakra: 10,
-            speedGauge: Math.floor(Math.random() * 200),
+            speedGauge: 600 + Math.floor(Math.random() * 200), // Enemies start at 600-800
             isPaused: false,
             isGuarding: false,
             statusEffects: [],

--- a/js/battle/battle-units.js
+++ b/js/battle/battle-units.js
@@ -79,11 +79,18 @@
      * Create combatant unit object
      */
     createCombatant(data) {
+      const isPlayer = data.isPlayer || false;
+
+      // Give enemies a head start (600-800 gauge) so they can act before fast players
+      const initialGauge = isPlayer
+        ? Math.floor(Math.random() * 200)  // Players: 0-200
+        : 600 + Math.floor(Math.random() * 200);  // Enemies: 600-800
+
       const unit = {
         id: data.uid || `unit-${Date.now()}-${Math.random()}`,
         name: data.name || "Unknown",
         portrait: data.portrait || "assets/characters/common/silhouette.png",
-        isPlayer: data.isPlayer || false,
+        isPlayer: isPlayer,
         positionId: data.positionId || 0,
         isActive: data.isActive !== undefined ? data.isActive : true,
         isBench: data.isBench || false,
@@ -91,7 +98,7 @@
         stats: data.stats,
         chakra: 0,
         maxChakra: 10,
-        speedGauge: Math.floor(Math.random() * 200),
+        speedGauge: initialGauge,
         isPaused: false,
         isGuarding: false,
         statusEffects: [],


### PR DESCRIPTION
Changed enemy starting speed gauge from 0-200 to 600-800 to ensure they get turns before fast player units monopolize the turn order.

Changes:
- BattleUnits.createCombatant: Enemies start at 600-800, players at 0-200
- Battle-missions fallback path: Enemies start at 600-800
- Players still reset to 0-200 between waves as before

This temporary fix gives enemies a head start until speed stats are balanced. With max gauge at 1200, enemies now start at 50-67% gauge while players start at 0-17%, ensuring enemies get initial turns.