### PR TITLE
Fix enemy AI by allowing enemies to build gauge during player turns

### DIFF
--- a/js/battle/battle-turns.js
+++ b/js/battle/battle-turns.js
@@ -130,16 +130,29 @@
     /* ===== Pause/Resume System ===== */
 
     /**
-     * Pause all units except current actor
-     * Prevents gauge advancement during turn
+     * Pause units based on who is acting
+     * - Player turn: Only pause other players (enemies build gauge)
+     * - Enemy turn: Pause all other units (traditional turn-based)
      */
     pauseAllOtherUnits(core) {
+      const currentIsPlayer = this.currentUnit.isPlayer;
+
       core.combatants.forEach(unit => {
-        if (unit !== this.currentUnit) {
+        if (unit === this.currentUnit) return;
+
+        if (currentIsPlayer) {
+          // Player turn: Only pause other players, let enemies build gauge
+          if (unit.isPlayer) {
+            unit.isPaused = true;
+          }
+        } else {
+          // Enemy turn: Pause all other units
           unit.isPaused = true;
         }
       });
-      console.log(`[Turns] All units paused except ${this.currentUnit.name}`);
+
+      const pausedType = currentIsPlayer ? "player units" : "all units";
+      console.log(`[Turns] ${pausedType} paused except ${this.currentUnit.name}`);
     },
 
     /**


### PR DESCRIPTION
Root cause: The pauseAllOtherUnits() function was pausing ALL units including enemies during player turns. With players having 300-500 speed vs enemies with 120 speed, players would monopolize turns and enemies never had enough unpause time to reach max gauge.

Solution: Modified pause system to be asymmetric:
- Player turn: Only pause other players, enemies continue building gauge
- Enemy turn: Pause all other units (traditional turn-based behavior)

This ensures enemies can build gauge to 1200 and take their turns while maintaining proper turn-based mechanics when enemies act.

Changes:
- js/battle/battle-turns.js: Updated pauseAllOtherUnits() logic