### PR TITLE
Give enemies much higher starting gauge (1100-1180) for first turn ad…

### DIFF
--- a/js/battle/battle-missions.js
+++ b/js/battle/battle-missions.js
@@ -103,7 +103,7 @@
             pos: { x: 70 + (i % 2 * 15), y: 25 + Math.floor(i / 2) * 25 },
             chakra: 0,
             maxChakra: 10,
-            speedGauge: 600 + Math.floor(Math.random() * 200), // Enemies start at 600-800
+            speedGauge: 1100 + Math.floor(Math.random() * 80), // Enemies start at 1100-1180 (almost ready)
             isPaused: false,
             isGuarding: false,
             statusEffects: [],

--- a/js/battle/battle-turns.js
+++ b/js/battle/battle-turns.js
@@ -130,29 +130,16 @@
     /* ===== Pause/Resume System ===== */
 
     /**
-     * Pause units based on who is acting
-     * - Player turn: Only pause other players (enemies build gauge)
-     * - Enemy turn: Pause all other units (traditional turn-based)
+     * Pause all units except current actor
+     * Prevents gauge advancement during turn
      */
     pauseAllOtherUnits(core) {
-      const currentIsPlayer = this.currentUnit.isPlayer;
-
       core.combatants.forEach(unit => {
-        if (unit === this.currentUnit) return;
-
-        if (currentIsPlayer) {
-          // Player turn: Only pause other players, let enemies build gauge
-          if (unit.isPlayer) {
-            unit.isPaused = true;
-          }
-        } else {
-          // Enemy turn: Pause all other units
+        if (unit !== this.currentUnit) {
           unit.isPaused = true;
         }
       });
-
-      const pausedType = currentIsPlayer ? "player units" : "all units";
-      console.log(`[Turns] ${pausedType} paused except ${this.currentUnit.name}`);
+      console.log(`[Turns] All units paused except ${this.currentUnit.name}`);
     },
 
     /**

--- a/js/battle/battle-units.js
+++ b/js/battle/battle-units.js
@@ -81,10 +81,11 @@
     createCombatant(data) {
       const isPlayer = data.isPlayer || false;
 
-      // Give enemies a head start (600-800 gauge) so they can act before fast players
+      // Give enemies a massive head start (1100-1180 gauge, almost at max 1200)
+      // This ensures enemies get their first turn, then normal speed-based turns take over
       const initialGauge = isPlayer
         ? Math.floor(Math.random() * 200)  // Players: 0-200
-        : 600 + Math.floor(Math.random() * 200);  // Enemies: 600-800
+        : 1100 + Math.floor(Math.random() * 80);  // Enemies: 1100-1180 (almost ready)
 
       const unit = {
         id: data.uid || `unit-${Date.now()}-${Math.random()}`,


### PR DESCRIPTION
…vantage

Reverted asymmetric pause system as it breaks speed-based turn mechanics. The real solution is giving enemies a massive head start on their gauge.

How this works:
- Enemies start at 1100-1180 gauge (very close to max 1200)
- Players start at 0-200 gauge
- Enemies get their first turn almost immediately
- After that, normal speed-based system takes over
- Players with 300-500 speed will act 3-4x more than enemies with 120 speed
- This preserves speed stat importance while ensuring enemies can act

Changes:
- js/battle/battle-turns.js: Restored original pauseAllOtherUnits()
- js/battle/battle-units.js: Increased enemy starting gauge 1100-1180
- js/battle/battle-missions.js: Updated fallback path to 1100-1180