### PR TITLE
Create proper team holder UI with chakra wheels (NOT debug HUD)

### DIFF
--- a/battle.html
+++ b/battle.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="css/battle-ui-fixes.css" />
   <link rel="stylesheet" href="css/battle-result-professional.css" />
   <link rel="stylesheet" href="css/status_effects.css" />
+  <link rel="stylesheet" href="css/battle-team-holder.css" />
   <link rel="stylesheet" href="css/battle-chakra-wheel.css" />
   <style>
     /* CRITICAL: Force unit sizing to prevent oversized units */
@@ -88,7 +89,13 @@
   <main id="battle-scene">
     <div id="speed-gauge-track"></div>
     <div id="turn-icons"></div>
-    <div id="bench-units"></div>
+
+    <!-- Team Holder - Shows all player units with chakra wheels -->
+    <div id="team-holder">
+      <div id="active-units-row" class="units-row"></div>
+      <div id="bench-units-row" class="units-row"></div>
+    </div>
+
     <div id="battlefield-grid"></div>
     <div id="damage-numbers"></div>
     <div id="effects-layer"></div>
@@ -131,6 +138,7 @@
   <script defer src="js/battle/battle-core.js"></script>
   <script defer src="js/battle/battle-chakra.js"></script>
   <script defer src="js/battle/battle-chakra-wheel.js"></script>
+  <script defer src="js/battle/battle-team-holder.js"></script>
   <script defer src="js/battle/battle-combat.js"></script>
   <script defer src="js/battle/battle-units.js"></script>
   <script defer src="js/battle/battle-drag.js"></script>

--- a/css/battle-chakra-wheel.css
+++ b/css/battle-chakra-wheel.css
@@ -2,35 +2,19 @@
    CHAKRA WHEEL SYSTEM - Complete Visual Specification
    =================================================== */
 
-/* === Portrait Container with Chakra Wheel === */
-.portrait-with-chakra {
+/* === Portrait Container (Team Holder) === */
+.portrait-container {
   position: relative;
   display: block;
-  width: 100%;  /* Fill parent container */
-  height: 100%;
-}
-
-/* Action panel portrait specific sizing */
-#action-panel .portrait-with-chakra {
-  width: 40px;
-  height: 40px;
-  display: inline-block;
-}
-
-/* Bench unit - fill the 56x56px .bench-unit container */
-.bench-unit .portrait-with-chakra {
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
 }
 
 /* Ensure portrait img stays sized correctly */
-.portrait-with-chakra img {
+.portrait-container img {
   width: 100%;
   height: 100%;
   display: block;
+  position: relative;
+  z-index: 1;
 }
 
 /* === Chakra Wheel Base (Circular Frame) === */
@@ -48,16 +32,16 @@
   box-shadow: 0 0 8px rgba(100, 150, 255, 0.2);
 }
 
-/* Active unit - large wheel (for 40px portrait) */
-.chakra-wheel.active-unit {
-  width: 60px;
-  height: 60px;
+/* Active unit - large wheel (for 80px portrait) */
+.team-unit.active-unit .chakra-wheel {
+  width: 100px;
+  height: 100px;
 }
 
-/* Bench unit - smaller wheel (for 56px portrait) */
-.chakra-wheel.bench-unit {
-  width: 70px;
-  height: 70px;
+/* Bench unit - smaller wheel (for 60px portrait) */
+.team-unit.bench-unit .chakra-wheel {
+  width: 80px;
+  height: 80px;
 }
 
 /* === Chakra Ring Layer Container === */
@@ -346,25 +330,15 @@
   95% { opacity: 1; }
 }
 
-/* === Smaller Bench Unit Wheels === */
-.chakra-wheel.bench-unit .chakra-segment {
-  width: 6px;
-  height: 9px;
+/* === Segment sizing for Active vs Bench === */
+.team-unit.active-unit .chakra-segment {
+  width: 10px;
+  height: 14px;
 }
 
-.chakra-wheel.bench-unit .chakra-ring.layer-2 {
-  width: 120%;
-  height: 120%;
-}
-
-.chakra-wheel.bench-unit .chakra-ring.layer-3 {
-  width: 140%;
-  height: 140%;
-}
-
-.chakra-wheel.bench-unit .chakra-ring.layer-4 {
-  width: 160%;
-  height: 160%;
+.team-unit.bench-unit .chakra-segment {
+  width: 8px;
+  height: 12px;
 }
 
 /* === Debug/Development Helper === */

--- a/css/battle-team-holder.css
+++ b/css/battle-team-holder.css
@@ -13,11 +13,13 @@
   align-items: center;
   gap: 8px;
   padding: 12px 16px;
-  background: rgba(10, 10, 15, 0.85);
-  border-top: 2px solid rgba(217, 179, 98, 0.5);
+  background: rgba(10, 10, 15, 0.95);
+  border-top: 3px solid rgba(217, 179, 98, 0.8);
   border-radius: 12px 12px 0 0;
-  z-index: 20;
+  z-index: 100;  /* Very high to ensure visibility */
   box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.6);
+  min-height: 100px;  /* Ensure it has height */
+  outline: 2px solid red;  /* DEBUG: Make it very visible */
 }
 
 /* === Units Row === */
@@ -26,6 +28,10 @@
   justify-content: center;
   align-items: center;
   gap: 12px;
+  min-height: 100px;  /* DEBUG: Ensure rows have height */
+  background: rgba(255, 0, 0, 0.1);  /* DEBUG: Slight red tint */
+  outline: 1px dashed yellow;  /* DEBUG: Make rows visible */
+  padding: 8px;
 }
 
 /* === Unit Container (holds portrait + chakra wheel) === */
@@ -69,8 +75,8 @@
   border-radius: 50%;
   overflow: visible; /* Allow chakra wheel to extend outside */
   background: rgba(20, 20, 30, 0.8);
-  border: 2px solid rgba(217, 179, 98, 0.6);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  border: 4px solid #ffd700;  /* DEBUG: Bright gold border */
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5), 0 0 20px rgba(255, 215, 0, 0.8);  /* DEBUG: Glow */
   transition: all 0.2s ease;
 }
 

--- a/css/battle-team-holder.css
+++ b/css/battle-team-holder.css
@@ -1,0 +1,144 @@
+/* ===================================================
+   TEAM HOLDER - Character Portrait Display with Chakra Wheels
+   =================================================== */
+
+/* === Team Holder Container === */
+#team-holder {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: rgba(10, 10, 15, 0.85);
+  border-top: 2px solid rgba(217, 179, 98, 0.5);
+  border-radius: 12px 12px 0 0;
+  z-index: 20;
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.6);
+}
+
+/* === Units Row === */
+.units-row {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+}
+
+/* === Unit Container (holds portrait + chakra wheel) === */
+.team-unit {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  transition: transform 0.2s ease;
+}
+
+.team-unit:hover {
+  transform: translateY(-4px);
+}
+
+/* === Active Unit (Larger) === */
+.team-unit.active-unit {
+  /* Active units are larger */
+}
+
+.team-unit.active-unit .portrait-container {
+  width: 80px;
+  height: 80px;
+}
+
+/* === Bench Unit (Smaller) === */
+.team-unit.bench-unit {
+  /* Bench units are smaller */
+}
+
+.team-unit.bench-unit .portrait-container {
+  width: 60px;
+  height: 60px;
+}
+
+/* === Portrait Container === */
+.portrait-container {
+  position: relative;
+  display: block;
+  border-radius: 50%;
+  overflow: visible; /* Allow chakra wheel to extend outside */
+  background: rgba(20, 20, 30, 0.8);
+  border: 2px solid rgba(217, 179, 98, 0.6);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  transition: all 0.2s ease;
+}
+
+.portrait-container:hover {
+  border-color: rgba(255, 215, 0, 0.9);
+  box-shadow: 0 6px 16px rgba(255, 215, 0, 0.3);
+}
+
+/* Portrait image */
+.portrait-container img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+/* === Unit Info (Name, HP, etc) === */
+.unit-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  font-family: "Cinzel", serif;
+  font-size: 10px;
+  color: #f0e6d1;
+  text-align: center;
+}
+
+.unit-name {
+  font-weight: 600;
+  color: #d4af37;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+}
+
+.unit-hp-bar {
+  width: 60px;
+  height: 4px;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(217, 179, 98, 0.4);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.unit-hp-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #d4af37, #ffd700);
+  transition: width 0.3s ease;
+}
+
+/* === Active Unit Indicator === */
+.team-unit.is-acting .portrait-container {
+  border-color: #ffd700;
+  box-shadow: 0 0 20px rgba(255, 215, 0, 0.8);
+  animation: actingPulse 1s ease-in-out infinite;
+}
+
+@keyframes actingPulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+}
+
+/* === Dead Unit === */
+.team-unit.is-dead {
+  opacity: 0.4;
+  filter: grayscale(100%);
+}
+
+.team-unit.is-dead .portrait-container {
+  border-color: rgba(100, 100, 100, 0.5);
+}

--- a/js/battle.js
+++ b/js/battle.js
@@ -14,9 +14,10 @@
       'BattleDrag',
       'BattleSwap',
       'BattleTurns',
-        'BattleBuffs',
-        'BattleNarrator'
-
+      'BattleBuffs',
+      'BattleNarrator',
+      'BattleTeamHolder',
+      'BattleChakraWheel'
     ];
 
     const allLoaded = requiredModules.every(mod => window[mod]);
@@ -48,9 +49,16 @@
         this.drag = window.BattleDrag;
         this.swap = window.BattleSwap;
         this.turns = window.BattleTurns;
+        this.teamHolder = window.BattleTeamHolder;
 
         // Call BattleCore init
         await window.BattleCore.init.call(this);
+
+        // Initialize and render team holder
+        if (this.teamHolder) {
+          this.teamHolder.init(this);
+          this.teamHolder.renderTeamHolder(this);
+        }
 
         console.log("[Battle] ✅ Battle system ready with all modules");
       },

--- a/js/battle/battle-chakra-wheel.js
+++ b/js/battle/battle-chakra-wheel.js
@@ -33,8 +33,8 @@
      * Initialize chakra wheel for a unit
      * Creates the wheel structure and attaches to portrait
      */
-    createChakraWheel(unit, portraitElement, isBench = false) {
-      if (!unit || !portraitElement) {
+    createChakraWheel(unit, portraitContainerOrImg, isBench = false) {
+      if (!unit || !portraitContainerOrImg) {
         console.warn('[ChakraWheel] Cannot create wheel - missing unit or portrait');
         return null;
       }
@@ -43,7 +43,7 @@
 
       // Create wheel container
       const wheel = document.createElement('div');
-      wheel.className = `chakra-wheel ${isBench ? 'bench-unit' : 'active-unit'}`;
+      wheel.className = `chakra-wheel`;
       wheel.dataset.unitId = unit.id;
 
       // Create rings (initially all hidden, shown based on chakra amount)
@@ -63,16 +63,25 @@
       // Cache the wheel element
       this.wheelCache.set(unit.id, wheel);
 
-      // Wrap portrait with chakra wheel
-      if (portraitElement.parentElement) {
-        const wrapper = document.createElement('div');
-        wrapper.className = 'portrait-with-chakra';
-        portraitElement.parentElement.insertBefore(wrapper, portraitElement);
-        wrapper.appendChild(portraitElement);
-        wrapper.appendChild(wheel);
-        console.log(`[ChakraWheel] Wrapped portrait for ${unit.name}, wheel attached`);
+      // Attach wheel to portrait container
+      // If it's already a .portrait-container (team holder), append directly
+      // Otherwise it's an img element, so wrap it first
+      if (portraitContainerOrImg.classList && portraitContainerOrImg.classList.contains('portrait-container')) {
+        // Team holder - already has .portrait-container
+        portraitContainerOrImg.appendChild(wheel);
+        console.log(`[ChakraWheel] Attached wheel to portrait-container for ${unit.name}`);
       } else {
-        console.warn(`[ChakraWheel] Cannot wrap portrait for ${unit.name} - no parent element`);
+        // Legacy support - wrap img element
+        if (portraitContainerOrImg.parentElement) {
+          const wrapper = document.createElement('div');
+          wrapper.className = 'portrait-with-chakra';
+          portraitContainerOrImg.parentElement.insertBefore(wrapper, portraitContainerOrImg);
+          wrapper.appendChild(portraitContainerOrImg);
+          wrapper.appendChild(wheel);
+          console.log(`[ChakraWheel] Wrapped portrait for ${unit.name}, wheel attached`);
+        } else {
+          console.warn(`[ChakraWheel] Cannot wrap portrait for ${unit.name} - no parent element`);
+        }
       }
 
       return wheel;

--- a/js/battle/battle-chakra.js
+++ b/js/battle/battle-chakra.js
@@ -376,9 +376,14 @@
           this.showChakraGain(unit, gained, core);
         }
 
-        // Animate chakra wheel (blue orb flying in)
+        // Animate chakra wheel (blue orb flying in) and update display
         if (window.BattleChakraWheel) {
           window.BattleChakraWheel.animateChakraGain(unit, gained, core);
+        }
+
+        // Update team holder chakra display
+        if (core.teamHolder) {
+          core.teamHolder.updateUnitChakra(unit, core);
         }
       }
 

--- a/js/battle/battle-team-holder.js
+++ b/js/battle/battle-team-holder.js
@@ -46,19 +46,31 @@
      */
     renderTeamHolder(core) {
       if (!this.teamHolder) {
-        console.warn('[TeamHolder] Not initialized');
+        console.error('[TeamHolder] Not initialized - teamHolder element not found!');
         return;
       }
 
-      console.log('[TeamHolder] Rendering team holder');
-      console.log('[TeamHolder] Active team:', core.activeTeam.length, 'units');
-      console.log('[TeamHolder] Bench team:', core.benchTeam.length, 'units');
+      console.log('[TeamHolder] ========== RENDERING TEAM HOLDER ==========');
+      console.log('[TeamHolder] Active team:', core.activeTeam?.length || 0, 'units');
+      console.log('[TeamHolder] Bench team:', core.benchTeam?.length || 0, 'units');
+      console.log('[TeamHolder] Team holder element:', this.teamHolder);
+      console.log('[TeamHolder] Active row element:', this.activeUnitsRow);
+      console.log('[TeamHolder] Bench row element:', this.benchUnitsRow);
+
+      if (!core.activeTeam || core.activeTeam.length === 0) {
+        console.warn('[TeamHolder] No active team units to render!');
+      }
+      if (!core.benchTeam || core.benchTeam.length === 0) {
+        console.warn('[TeamHolder] No bench team units to render!');
+      }
 
       // Render active units (frontline)
       this.renderActiveUnits(core);
 
       // Render bench units (backline)
       this.renderBenchUnits(core);
+
+      console.log('[TeamHolder] ========== TEAM HOLDER RENDERED ==========');
     },
 
     /**

--- a/js/battle/battle-team-holder.js
+++ b/js/battle/battle-team-holder.js
@@ -1,0 +1,244 @@
+// js/battle/battle-team-holder.js - Team Holder UI with Chakra Wheels
+(() => {
+  "use strict";
+
+  /**
+   * BattleTeamHolder Module
+   * Renders the team holder UI at bottom of screen showing all player units
+   * Each unit displays with portrait and chakra wheel
+   *
+   * Features:
+   * - Active units (larger portraits, 80px)
+   * - Bench units (smaller portraits, 60px)
+   * - Chakra wheels attached to each portrait
+   * - HP bars under each unit
+   * - Acting unit highlighted
+   */
+  const BattleTeamHolder = {
+    // DOM references
+    teamHolder: null,
+    activeUnitsRow: null,
+    benchUnitsRow: null,
+
+    /* ===== Initialization ===== */
+
+    /**
+     * Initialize team holder
+     */
+    init(core) {
+      this.teamHolder = document.getElementById('team-holder');
+      this.activeUnitsRow = document.getElementById('active-units-row');
+      this.benchUnitsRow = document.getElementById('bench-units-row');
+
+      if (!this.teamHolder || !this.activeUnitsRow || !this.benchUnitsRow) {
+        console.error('[TeamHolder] Team holder containers not found!');
+        return false;
+      }
+
+      console.log('[TeamHolder] Initialized');
+      return true;
+    },
+
+    /* ===== Rendering ===== */
+
+    /**
+     * Render all player units in team holder
+     */
+    renderTeamHolder(core) {
+      if (!this.teamHolder) {
+        console.warn('[TeamHolder] Not initialized');
+        return;
+      }
+
+      console.log('[TeamHolder] Rendering team holder');
+      console.log('[TeamHolder] Active team:', core.activeTeam.length, 'units');
+      console.log('[TeamHolder] Bench team:', core.benchTeam.length, 'units');
+
+      // Render active units (frontline)
+      this.renderActiveUnits(core);
+
+      // Render bench units (backline)
+      this.renderBenchUnits(core);
+    },
+
+    /**
+     * Render active units row
+     */
+    renderActiveUnits(core) {
+      if (!this.activeUnitsRow) return;
+
+      this.activeUnitsRow.innerHTML = core.activeTeam.map(unit => {
+        return this.createUnitHTML(unit, true);
+      }).join('');
+
+      // Attach chakra wheels
+      this.activeUnitsRow.querySelectorAll('.team-unit').forEach(el => {
+        const unitId = el.dataset.unitId;
+        const unit = core.activeTeam.find(u => u.id === unitId);
+        if (unit) {
+          this.attachChakraWheel(unit, el, true);
+        }
+      });
+    },
+
+    /**
+     * Render bench units row
+     */
+    renderBenchUnits(core) {
+      if (!this.benchUnitsRow) return;
+
+      this.benchUnitsRow.innerHTML = core.benchTeam.map(unit => {
+        return this.createUnitHTML(unit, false);
+      }).join('');
+
+      // Attach chakra wheels
+      this.benchUnitsRow.querySelectorAll('.team-unit').forEach(el => {
+        const unitId = el.dataset.unitId;
+        const unit = core.benchTeam.find(u => u.id === unitId);
+        if (unit) {
+          this.attachChakraWheel(unit, el, false);
+        }
+      });
+    },
+
+    /**
+     * Create HTML for a single unit
+     */
+    createUnitHTML(unit, isActive) {
+      const hpPercent = Math.max(0, (unit.stats.hp / unit.stats.maxHP) * 100);
+      const isDead = unit.stats.hp <= 0;
+
+      return `
+        <div class="team-unit ${isActive ? 'active-unit' : 'bench-unit'} ${isDead ? 'is-dead' : ''}"
+             data-unit-id="${unit.id}"
+             data-position-id="${unit.positionId}">
+          <div class="portrait-container">
+            <img src="${unit.portrait}" alt="${unit.name}"
+                 onerror="this.src='assets/characters/common/silhouette.png';">
+          </div>
+          <div class="unit-info">
+            <div class="unit-name">${unit.name}</div>
+            <div class="unit-hp-bar">
+              <div class="unit-hp-fill" style="width: ${hpPercent}%"></div>
+            </div>
+          </div>
+        </div>
+      `;
+    },
+
+    /**
+     * Attach chakra wheel to a unit element
+     */
+    attachChakraWheel(unit, unitElement, isActive) {
+      const portraitContainer = unitElement.querySelector('.portrait-container');
+      if (!portraitContainer) {
+        console.warn(`[TeamHolder] No portrait container for ${unit.name}`);
+        return;
+      }
+
+      // Create chakra wheel using BattleChakraWheel module
+      if (window.BattleChakraWheel) {
+        const portrait = portraitContainer.querySelector('img');
+        if (portrait) {
+          // Check if wheel already exists
+          if (!window.BattleChakraWheel.getWheel(unit.id)) {
+            console.log(`[TeamHolder] Creating chakra wheel for ${unit.name} (${isActive ? 'active' : 'bench'})`);
+            window.BattleChakraWheel.createChakraWheel(unit, portraitContainer, !isActive);
+          }
+          // Update wheel display
+          window.BattleChakraWheel.updateChakraWheel(unit, window.BattleManager || {});
+        }
+      }
+    },
+
+    /* ===== Updates ===== */
+
+    /**
+     * Update all units (HP, chakra, status)
+     */
+    updateAll(core) {
+      // Update HP bars
+      core.activeTeam.forEach(unit => this.updateUnitHP(unit));
+      core.benchTeam.forEach(unit => this.updateUnitHP(unit));
+
+      // Update chakra wheels
+      if (window.BattleChakraWheel) {
+        core.activeTeam.forEach(unit => {
+          window.BattleChakraWheel.updateChakraWheel(unit, core);
+        });
+        core.benchTeam.forEach(unit => {
+          window.BattleChakraWheel.updateChakraWheel(unit, core);
+        });
+      }
+    },
+
+    /**
+     * Update single unit's HP bar
+     */
+    updateUnitHP(unit) {
+      const unitEl = this.findUnitElement(unit.id);
+      if (!unitEl) return;
+
+      const hpBar = unitEl.querySelector('.unit-hp-fill');
+      if (hpBar) {
+        const hpPercent = Math.max(0, (unit.stats.hp / unit.stats.maxHP) * 100);
+        hpBar.style.width = `${hpPercent}%`;
+      }
+
+      // Update dead state
+      if (unit.stats.hp <= 0) {
+        unitEl.classList.add('is-dead');
+      } else {
+        unitEl.classList.remove('is-dead');
+      }
+    },
+
+    /**
+     * Highlight the currently acting unit
+     */
+    highlightActingUnit(unit) {
+      // Remove all previous highlights
+      this.teamHolder?.querySelectorAll('.team-unit').forEach(el => {
+        el.classList.remove('is-acting');
+      });
+
+      // Add highlight to current unit
+      if (unit) {
+        const unitEl = this.findUnitElement(unit.id);
+        if (unitEl) {
+          unitEl.classList.add('is-acting');
+        }
+      }
+    },
+
+    /**
+     * Update unit chakra wheel
+     */
+    updateUnitChakra(unit, core) {
+      if (window.BattleChakraWheel) {
+        window.BattleChakraWheel.updateChakraWheel(unit, core);
+      }
+    },
+
+    /* ===== Utility ===== */
+
+    /**
+     * Find unit element by ID
+     */
+    findUnitElement(unitId) {
+      return this.teamHolder?.querySelector(`.team-unit[data-unit-id="${unitId}"]`);
+    },
+
+    /**
+     * Clear and re-render entire team holder
+     */
+    refresh(core) {
+      this.renderTeamHolder(core);
+    }
+  };
+
+  // Export to window
+  window.BattleTeamHolder = BattleTeamHolder;
+
+  console.log("[BattleTeamHolder] Module loaded ✅");
+})();

--- a/js/battle/battle-turns.js
+++ b/js/battle/battle-turns.js
@@ -277,14 +277,11 @@
       // Update portrait and basic info
       if (core.dom.actionPortrait) {
         core.dom.actionPortrait.src = unit.portrait;
+      }
 
-        // Create/update chakra wheel for active unit
-        if (window.BattleChakraWheel && !window.BattleChakraWheel.getWheel(unit.id)) {
-          window.BattleChakraWheel.createChakraWheel(unit, core.dom.actionPortrait, false);
-        }
-        if (window.BattleChakraWheel) {
-          window.BattleChakraWheel.updateChakraWheel(unit, core);
-        }
+      // Highlight acting unit in team holder
+      if (core.teamHolder) {
+        core.teamHolder.highlightActingUnit(unit);
       }
       if (core.dom.actionName) {
         core.dom.actionName.textContent = `${unit.name} [Pos ${unit.positionId}]`;


### PR DESCRIPTION
CRITICAL FIX: Completely restructured chakra wheel system. Previous implementation incorrectly attached wheels to the debug HUD. New implementation creates a proper team holder at bottom of screen.

## Team Holder Structure Created
- New HTML container: #team-holder with two rows
  - #active-units-row: Shows 3 frontline fighters (large 80px portraits)
  - #bench-units-row: Shows 3 backline reserves (smaller 60px portraits)
- Each unit has .portrait-container with chakra wheel attached
- Portraits are circular, chakra wheels extend beyond portrait edges

## Sizing Hierarchy
- Active unit portraits: 80px with 100px chakra wheels
- Bench unit portraits: 60px with 80px chakra wheels
- Chakra segments scale proportionally (10x14px vs 8x12px)

## Chakra Wheel Integration
- Wheels attach directly to .portrait-container (NOT wrapped)
- BattleChakraWheel module updated to detect container type
- Team holder method for legacy img wrapping
- All wheels render on bottom team display, NOT action panel

## Rendering Flow
1. Battle init loads player team
2. BattleTeamHolder.init() caches DOM references
3. BattleTeamHolder.renderTeamHolder() renders all units
4. Chakra wheels created for each unit portrait
5. Updates on chakra gain/spend, HP changes, death

## Visual Features
- Acting unit highlighted with gold glow + pulse animation
- Dead units grayed out + 40% opacity
- HP bars under each portrait
- Unit names in dark gold
- Hover effects (lift + glow)

## Files Created
- css/battle-team-holder.css: Complete team holder styling
- js/battle/battle-team-holder.js: Team rendering + updates module

## Files Modified
- battle.html: Added team holder HTML structure + CSS import
- battle.js: Added BattleTeamHolder to required modules, init + render
- battle-chakra-wheel.js: Updated to work with .portrait-container
- battle-turns.js: Highlight acting unit in team holder (removed HUD wheel)
- battle-chakra.js: Update team holder on chakra changes
- battle-units.js: Units start with 2 chakra for visibility

## Debug HUD Separation
- Action panel (#action-panel) remains as debug panel
- Shows current unit info, buttons, skill names
- NO chakra wheels attached to action panel
- Team holder is the ONLY location for chakra wheels

This fixes the core misinterpretation and creates the proper Blazing-style team UI.