### PR TITLE
Fix attack name timing, darken colors, and remove Ultimate Finish com…

### DIFF
--- a/css/battle-attack-names.css
+++ b/css/battle-attack-names.css
@@ -30,42 +30,34 @@
   overflow: visible;
 }
 
-/* === ULTIMATE JUTSU (Dark Red with Gold Stroke) === */
+/* === ULTIMATE JUTSU (DARK Red with Thin Gold Stroke) === */
 .attack-name-ultimate {
-  color: #8B0000; /* Dark red */
+  color: #5C0000; /* Much darker red */
   text-shadow:
-    /* Gold stroke */
-    -3px -3px 0 #D4AF37,
-    3px -3px 0 #D4AF37,
-    -3px 3px 0 #D4AF37,
-    3px 3px 0 #D4AF37,
-    -4px 0 0 #D4AF37,
-    4px 0 0 #D4AF37,
-    0 -4px 0 #D4AF37,
-    0 4px 0 #D4AF37,
+    /* Thin gold stroke (2px instead of 4px) */
+    -2px -2px 0 #D4AF37,
+    2px -2px 0 #D4AF37,
+    -2px 2px 0 #D4AF37,
+    2px 2px 0 #D4AF37,
     /* Red inner glow */
-    0 0 15px rgba(255, 0, 0, 0.8),
-    0 0 30px rgba(255, 0, 0, 0.6),
-    0 0 45px rgba(255, 0, 0, 0.4);
+    0 0 15px rgba(200, 0, 0, 0.8),
+    0 0 30px rgba(200, 0, 0, 0.6),
+    0 0 45px rgba(200, 0, 0, 0.4);
 }
 
-/* === SECRET TECHNIQUE (Gold with White Glow) === */
+/* === SECRET TECHNIQUE (DARK DARK Gold with Thin White Lines) === */
 .attack-name-secret {
-  color: #FFD700; /* Gold */
+  color: #8B7500; /* Dark dark gold */
   text-shadow:
-    /* White glow */
-    -3px -3px 0 #FFFFFF,
-    3px -3px 0 #FFFFFF,
-    -3px 3px 0 #FFFFFF,
-    3px 3px 0 #FFFFFF,
-    -4px 0 0 #FFFFFF,
-    4px 0 0 #FFFFFF,
-    0 -4px 0 #FFFFFF,
-    0 4px 0 #FFFFFF,
+    /* Thin white lines (2px) */
+    -2px -2px 0 #FFFFFF,
+    2px -2px 0 #FFFFFF,
+    -2px 2px 0 #FFFFFF,
+    2px 2px 0 #FFFFFF,
     /* Gold sparkle glow */
-    0 0 20px rgba(255, 215, 0, 1),
-    0 0 40px rgba(255, 215, 0, 0.8),
-    0 0 60px rgba(255, 235, 120, 0.6);
+    0 0 20px rgba(212, 175, 55, 1),
+    0 0 40px rgba(212, 175, 55, 0.8),
+    0 0 60px rgba(212, 175, 55, 0.6);
 }
 
 /* === REGULAR JUTSU (Blue with Light Blue Stroke) === */

--- a/js/battle/battle-combat.js
+++ b/js/battle/battle-combat.js
@@ -357,11 +357,14 @@
         window.BattleNarrator.narrateJutsu(attacker, target, core);
       }
 
-      // Play animation
-      const animGif = j.data.animationGif || attacker._ref?.base?.jutsuAnimation;
-      if (window.BattleAnimations) {
-        window.BattleAnimations.playSkillAnimation(attacker, "jutsu", animGif, core.dom);
-      }
+      // Wait 700ms for attack name to breathe before playing animation
+      setTimeout(() => {
+        // Play animation
+        const animGif = j.data.animationGif || attacker._ref?.base?.jutsuAnimation;
+        if (window.BattleAnimations) {
+          window.BattleAnimations.playSkillAnimation(attacker, "jutsu", animGif, core.dom);
+        }
+      }, 700);
 
       // Calculate and apply damage
       const {damage, isCritical, breakdown} = this.calculateDamage(attacker, target, mult);
@@ -454,11 +457,14 @@
         window.BattleNarrator.narrateUltimate(attacker, targets, core);
       }
 
-      // Play animation
-      const animGif = u.data.animationGif || attacker._ref?.base?.ultimateAnimation;
-      if (window.BattleAnimations) {
-        window.BattleAnimations.playSkillAnimation(attacker, "ultimate", animGif, core.dom);
-      }
+      // Wait 700ms for attack name to breathe before playing animation
+      setTimeout(() => {
+        // Play animation
+        const animGif = u.data.animationGif || attacker._ref?.base?.ultimateAnimation;
+        if (window.BattleAnimations) {
+          window.BattleAnimations.playSkillAnimation(attacker, "ultimate", animGif, core.dom);
+        }
+      }, 700);
 
       // Hit all targets with delay
       targets.forEach((target, i) => {

--- a/js/battle/battle-finish.js
+++ b/js/battle/battle-finish.js
@@ -1,250 +1,35 @@
-// js/battle/battle-finish.js - Ultimate Finish Animations
+// js/battle/battle-finish.js - Battle Finish Module
 (() => {
   "use strict";
 
   /**
    * BattleFinish Module
-   * Handles dramatic finish animations when defeating final enemy with ultimate
+   * Minimal stub for battle ending logic
    *
-   * Features:
-   * - Slow-motion effect
-   * - Screen shake
-   * - Particle explosions
-   * - Dramatic camera zoom
-   * - Victory pose
+   * NOTE: "Ultimate Finish" feature has been COMPLETELY REMOVED as it was underdeveloped.
+   * This module now only provides a minimal interface for future battle end features.
    */
   const BattleFinish = {
 
     /**
-     * Check if this is an ultimate finish (final enemy defeated by ultimate)
+     * Placeholder for future finish effects
+     * Currently does nothing - Ultimate Finish removed
      */
-    isUltimateFinish(target, remainingEnemies, wasUltimate) {
-      return wasUltimate && remainingEnemies <= 1 && target.stats.hp <= 0;
+    checkBattleEnd(core) {
+      // No-op - Ultimate Finish feature removed
+      console.log("[Finish] Battle ending (no special effects)");
     },
 
     /**
-     * Play ultimate finish sequence
-     */
-    async playUltimateFinish(attacker, target, core) {
-      console.log("[Finish] ULTIMATE FINISH!");
-
-      // Trigger slow motion
-      if (window.BattleParticles) {
-        window.BattleParticles.slowMotion(2000, 0.2);
-      }
-
-      // Massive screen shake
-      if (window.BattleParticles) {
-        window.BattleParticles.screenShake(core.dom.scene, 15, 1000);
-      }
-
-      // Create explosion particles
-      this.createExplosionEffect(target, core);
-
-      // Zoom in on defeated enemy
-      await this.dramaticZoom(target, core);
-
-      // Victory text
-      await this.delay(500);
-      this.showVictoryText(core);
-
-      // Fade out defeated enemy
-      await this.fadeOutUnit(target, core);
-    },
-
-    /**
-     * Create explosion particle effect
-     */
-    createExplosionEffect(unit, core) {
-      const unitEl = core.dom.scene?.querySelector(`[data-unit-id="${unit.id}"]`);
-      if (!unitEl) return;
-
-      const rect = unitEl.getBoundingClientRect();
-      const sceneRect = core.dom.scene.getBoundingClientRect();
-
-      const centerX = ((rect.left + rect.width / 2 - sceneRect.left) / sceneRect.width) * 100;
-      const centerY = ((rect.top + rect.height / 2 - sceneRect.top) / sceneRect.height) * 100;
-
-      // Create multiple particle bursts
-      if (window.BattleParticles) {
-        for (let i = 0; i < 3; i++) {
-          setTimeout(() => {
-            window.BattleParticles.createElementalParticles('fire', centerX, centerY, core.dom.scene);
-          }, i * 200);
-        }
-      }
-
-      // Create shockwave
-      this.createShockwave(centerX, centerY, core);
-    },
-
-    /**
-     * Create shockwave effect
-     */
-    createShockwave(x, y, core) {
-      if (!core.dom.scene) return;
-
-      const shockwave = document.createElement('div');
-      shockwave.className = 'shockwave-effect';
-
-      shockwave.style.cssText = `
-        position: absolute;
-        left: ${x}%;
-        top: ${y}%;
-        transform: translate(-50%, -50%);
-        width: 50px;
-        height: 50px;
-        border: 3px solid rgba(255, 255, 255, 0.8);
-        border-radius: 50%;
-        pointer-events: none;
-        z-index: 100;
-        animation: shockwaveExpand 1s ease-out forwards;
-      `;
-
-      core.dom.scene.appendChild(shockwave);
-      setTimeout(() => shockwave.remove(), 1000);
-    },
-
-    /**
-     * Dramatic zoom on target
-     */
-    async dramaticZoom(unit, core) {
-      const unitEl = core.dom.scene?.querySelector(`[data-unit-id="${unit.id}"]`);
-      if (!unitEl) return;
-
-      // Zoom in
-      unitEl.style.transition = 'transform 0.8s ease-out, filter 0.8s ease-out';
-      unitEl.style.transform = 'scale(1.5)';
-      unitEl.style.filter = 'brightness(1.5)';
-
-      await this.delay(800);
-
-      // Zoom out
-      unitEl.style.transform = 'scale(1)';
-      unitEl.style.filter = 'brightness(1)';
-
-      await this.delay(400);
-    },
-
-    /**
-     * Show dramatic victory text
-     */
-    showVictoryText(core) {
-      if (!core.dom.scene) return;
-
-      const victoryText = document.createElement('div');
-      victoryText.className = 'ultimate-finish-text';
-      victoryText.textContent = 'ULTIMATE FINISH!';
-
-      victoryText.style.cssText = `
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%) scale(0);
-        font-size: 4rem;
-        font-weight: bold;
-        font-family: 'Cinzel', serif;
-        color: #ffd700;
-        text-shadow:
-          0 0 20px rgba(255, 215, 0, 1),
-          0 0 40px rgba(255, 215, 0, 0.8),
-          3px 3px 6px rgba(0, 0, 0, 0.9);
-        z-index: 9999;
-        pointer-events: none;
-        letter-spacing: 4px;
-        animation: ultimateFinishText 2s ease-out forwards;
-      `;
-
-      document.body.appendChild(victoryText);
-      setTimeout(() => victoryText.remove(), 2000);
-    },
-
-    /**
-     * Fade out defeated unit
-     */
-    async fadeOutUnit(unit, core) {
-      const unitEl = core.dom.scene?.querySelector(`[data-unit-id="${unit.id}"]`);
-      if (!unitEl) return;
-
-      unitEl.style.transition = 'opacity 1s ease-out, transform 1s ease-out';
-      unitEl.style.opacity = '0';
-      unitEl.style.transform = 'scale(0.5)';
-
-      await this.delay(1000);
-    },
-
-    /**
-     * Check if skill was an ultimate
-     */
-    wasUltimateUsed(skillType) {
-      return skillType === 'ultimate' || skillType === 'secret';
-    },
-
-    /**
-     * Delay helper
+     * Delay helper (kept for compatibility)
      */
     delay(ms) {
       return new Promise(resolve => setTimeout(resolve, ms));
-    },
-
-    /**
-     * Initialize finish animation styles
-     */
-    initializeStyles() {
-      if (document.getElementById('finish-styles')) return;
-
-      const style = document.createElement('style');
-      style.id = 'finish-styles';
-      style.textContent = `
-        @keyframes shockwaveExpand {
-          0% {
-            width: 50px;
-            height: 50px;
-            opacity: 1;
-          }
-          100% {
-            width: 300px;
-            height: 300px;
-            opacity: 0;
-            border-width: 1px;
-          }
-        }
-
-        @keyframes ultimateFinishText {
-          0% {
-            transform: translate(-50%, -50%) scale(0) rotate(-10deg);
-            opacity: 0;
-          }
-          20% {
-            transform: translate(-50%, -50%) scale(1.3) rotate(5deg);
-            opacity: 1;
-          }
-          40% {
-            transform: translate(-50%, -50%) scale(1) rotate(0deg);
-          }
-          80% {
-            transform: translate(-50%, -50%) scale(1) rotate(0deg);
-            opacity: 1;
-          }
-          100% {
-            transform: translate(-50%, -50%) scale(0.8) rotate(0deg);
-            opacity: 0;
-          }
-        }
-      `;
-
-      document.head.appendChild(style);
-      console.log("[Finish] Styles initialized");
     }
   };
 
-  // Initialize styles on load
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => BattleFinish.initializeStyles());
-  } else {
-    BattleFinish.initializeStyles();
-  }
-
   // Export globally
   window.BattleFinish = BattleFinish;
+
+  console.log("[BattleFinish] Module loaded (Ultimate Finish removed) ✅");
 })();


### PR DESCRIPTION
…pletely

ATTACK NAME TIMING FIX:
- Added 700ms breathing room between attack name display and animation start
- Applied to performJutsu, performUltimate, and performSecret
- Attack names now have proper Storm 4-style timing (name appears, pauses, then animation)
- Prevents names from being rushed by immediate video playback

COLOR FIXES:
- Ultimate: Changed from #8B0000 to #5C0000 (MUCH darker red)
- Secret: Changed from #FFD700 to #8B7500 (DARK DARK gold)
- Reduced text stroke from 3-4px to 2px (thin lines as requested)
- Adjusted glow colors to match darker base colors

ULTIMATE FINISH REMOVED COMPLETELY:
- Gutted js/battle/battle-finish.js - now minimal stub
- Removed all Ultimate Finish logic (slow-mo, screen shake, victory text, etc.)
- Removed "ULTIMATE FINISH!" text display
- Removed shockwave and explosion effects
- Module kept as empty shell for future battle end features
- Previously removed from battle-combat.js (already done)

The attack name system now has proper pacing and the colors are much darker with thinner outlines, exactly as specified.