### PR TITLE
Restore shockwave and screen shake effects (remove only the text)

### DIFF
--- a/js/battle/battle-combat.js
+++ b/js/battle/battle-combat.js
@@ -472,6 +472,19 @@
           const {damage, isCritical, breakdown} = this.calculateDamage(attacker, target, mult);
           target.stats.hp = Math.max(0, target.stats.hp - damage);
 
+          // Check if this defeats the final enemy (trigger shockwave + screen shake)
+          const remainingEnemies = core.enemyTeam.filter(e => e.stats.hp > 0).length;
+          const shouldFinish = window.BattleFinish?.shouldTriggerFinish(target, remainingEnemies, true);
+
+          if (shouldFinish) {
+            // Trigger finish effects (shockwave + screen shake, NO text)
+            setTimeout(() => {
+              if (window.BattleFinish) {
+                window.BattleFinish.playFinishEffects(attacker, target, core);
+              }
+            }, 300);
+          }
+
           // Apply knockback for ultimate
           if (window.BattlePhysics) {
             window.BattlePhysics.applyKnockback(target, attacker, 60, core);

--- a/js/battle/battle-finish.js
+++ b/js/battle/battle-finish.js
@@ -1,35 +1,145 @@
-// js/battle/battle-finish.js - Battle Finish Module
+// js/battle/battle-finish.js - Battle Finish Effects
 (() => {
   "use strict";
 
   /**
    * BattleFinish Module
-   * Minimal stub for battle ending logic
+   * Handles dramatic finish effects when defeating final enemy with ultimate/secret
    *
-   * NOTE: "Ultimate Finish" feature has been COMPLETELY REMOVED as it was underdeveloped.
-   * This module now only provides a minimal interface for future battle end features.
+   * Features:
+   * - Shockwave effect
+   * - Screen shake
+   * - Particle explosions
+   * - NO text display (removed "Ultimate Finish!" text)
    */
   const BattleFinish = {
 
     /**
-     * Placeholder for future finish effects
-     * Currently does nothing - Ultimate Finish removed
+     * Check if this should trigger finish effects (final enemy defeated by ultimate/secret)
      */
-    checkBattleEnd(core) {
-      // No-op - Ultimate Finish feature removed
-      console.log("[Finish] Battle ending (no special effects)");
+    shouldTriggerFinish(target, remainingEnemies, wasUltimate) {
+      return wasUltimate && remainingEnemies <= 1 && target.stats.hp <= 0;
     },
 
     /**
-     * Delay helper (kept for compatibility)
+     * Play finish effects (shockwave + screen shake, NO text)
+     */
+    async playFinishEffects(attacker, target, core) {
+      console.log("[Finish] Final enemy defeated with ultimate/secret!");
+
+      // Massive screen shake
+      if (window.BattleParticles) {
+        window.BattleParticles.screenShake(core.dom.scene, 15, 800);
+      }
+
+      // Create explosion particles
+      this.createExplosionEffect(target, core);
+
+      // Wait briefly then end battle
+      await this.delay(1000);
+    },
+
+    /**
+     * Create explosion particle effect
+     */
+    createExplosionEffect(unit, core) {
+      const unitEl = core.dom.scene?.querySelector(`[data-unit-id="${unit.id}"]`);
+      if (!unitEl) return;
+
+      const rect = unitEl.getBoundingClientRect();
+      const sceneRect = core.dom.scene.getBoundingClientRect();
+
+      const centerX = ((rect.left + rect.width / 2 - sceneRect.left) / sceneRect.width) * 100;
+      const centerY = ((rect.top + rect.height / 2 - sceneRect.top) / sceneRect.height) * 100;
+
+      // Create multiple particle bursts
+      if (window.BattleParticles) {
+        for (let i = 0; i < 3; i++) {
+          setTimeout(() => {
+            window.BattleParticles.createElementalParticles('fire', centerX, centerY, core.dom.scene);
+          }, i * 150);
+        }
+      }
+
+      // Create shockwave
+      this.createShockwave(centerX, centerY, core);
+    },
+
+    /**
+     * Create shockwave effect
+     */
+    createShockwave(x, y, core) {
+      if (!core.dom.scene) return;
+
+      const shockwave = document.createElement('div');
+      shockwave.className = 'battle-shockwave-effect';
+
+      shockwave.style.cssText = `
+        position: absolute;
+        left: ${x}%;
+        top: ${y}%;
+        transform: translate(-50%, -50%);
+        width: 50px;
+        height: 50px;
+        border: 4px solid rgba(255, 215, 0, 0.9);
+        border-radius: 50%;
+        pointer-events: none;
+        z-index: 100;
+        box-shadow:
+          0 0 20px rgba(255, 215, 0, 0.8),
+          inset 0 0 20px rgba(255, 215, 0, 0.5);
+        animation: shockwaveExpand 0.8s ease-out forwards;
+      `;
+
+      core.dom.scene.appendChild(shockwave);
+      setTimeout(() => shockwave.remove(), 800);
+    },
+
+    /**
+     * Delay helper
      */
     delay(ms) {
       return new Promise(resolve => setTimeout(resolve, ms));
+    },
+
+    /**
+     * Initialize finish effect styles
+     */
+    initializeStyles() {
+      if (document.getElementById('finish-styles')) return;
+
+      const style = document.createElement('style');
+      style.id = 'finish-styles';
+      style.textContent = `
+        @keyframes shockwaveExpand {
+          0% {
+            width: 50px;
+            height: 50px;
+            opacity: 1;
+          }
+          100% {
+            width: 400px;
+            height: 400px;
+            opacity: 0;
+            border-width: 1px;
+          }
+        }
+      `;
+
+      document.head.appendChild(style);
+      console.log("[Finish] Shockwave styles initialized");
     }
   };
+
+  // Initialize styles on load
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => BattleFinish.initializeStyles());
+  } else {
+    BattleFinish.initializeStyles();
+  }
 
   // Export globally
   window.BattleFinish = BattleFinish;
 
-  console.log("[BattleFinish] Module loaded (Ultimate Finish removed) ✅");
+  console.log("[BattleFinish] Module loaded (shockwave + screen shake enabled) ✅");
 })();


### PR DESCRIPTION
RESTORED FINISH EFFECTS:
- Shockwave animation (gold expanding ring with glow)
- Screen shake (intensity 15, 800ms duration)
- Particle explosion bursts (3 fire particle bursts)
- Triggers when final enemy defeated by ultimate/secret

KEPT REMOVED:
- "ULTIMATE FINISH!" text display (cringey, stays gone)

The finish effects now provide dramatic visual feedback without the text. When the last enemy is defeated with an ultimate or secret technique:
1. Gold shockwave expands from defeated enemy (50px → 400px)
2. Screen shakes dramatically
3. Fire particles burst at enemy location
4. NO text appears

This keeps the impactful visual effects while removing the cheesy text overlay.