### PR TITLE
Switch to chakra accumulation system (Naruto Blazing style)

### DIFF
--- a/css/battle-chakra-wheel.css
+++ b/css/battle-chakra-wheel.css
@@ -1,11 +1,10 @@
 /* ===================================================
-   IMAGE-BASED CIRCULAR CHAKRA GAUGE SYSTEM
-   Naruto Blazing-Style Rotating Chakra Gauge
+   CHAKRA ACCUMULATION SYSTEM (Naruto Blazing Style)
+   Multiple Static Segments, No Rotation
    =================================================== */
 
-/* === Chakra Slot Container === */
-/* Active units: 140px container */
-.chakra-slot {
+/* === Unit Ring Container === */
+.unit-ring {
   position: relative;
   width: 140px;
   height: 140px;
@@ -13,49 +12,18 @@
   transition: transform 0.2s ease;
 }
 
-.chakra-slot:hover {
+.unit-ring:hover {
   transform: scale(1.05);
 }
 
 /* Bench units: 100px container */
-.bench-portrait-container .chakra-slot {
+.bench-portrait-container .unit-ring {
   width: 100px;
   height: 100px;
 }
 
-/* === Chakra Mask (Contains Rotating Segment) === */
-.chakra-mask {
-  position: absolute;
-  top: 6px;
-  left: 6px;
-  width: 128px;
-  height: 128px;
-  border-radius: 50%;
-  clip-path: circle(50%);
-  overflow: hidden;
-  z-index: 2; /* Above portrait, below frame */
-}
-
-.bench-portrait-container .chakra-mask {
-  top: 6px;
-  left: 6px;
-  width: 88px;
-  height: 88px;
-}
-
-/* === Chakra Segment (Rotating Blue Arc) === */
-.chakra-segment {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  transform-origin: center center;
-  transition: transform 0.3s ease-out;
-}
-
-/* === Portrait (Clipped Circle, Below Gauge) === */
-.portrait-clipped {
+/* === Portrait (Bottom Layer, z-index: 1) === */
+.portrait {
   position: absolute;
   top: 6px;
   left: 6px;
@@ -64,17 +32,43 @@
   border-radius: 50%;
   clip-path: circle(50%);
   object-fit: cover;
-  z-index: 1; /* Middle layer */
+  z-index: 1;
 }
 
-.bench-portrait-container .portrait-clipped {
-  top: 6px;
-  left: 6px;
+.bench-portrait-container .portrait {
   width: 88px;
   height: 88px;
 }
 
-/* === Chakra Frame (Top Layer) === */
+/* === Chakra Container (Middle Layer, z-index: 2) === */
+.chakra-container {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  width: 128px;
+  height: 128px;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.bench-portrait-container .chakra-container {
+  width: 88px;
+  height: 88px;
+}
+
+/* === Chakra Segments (Accumulate, Don't Rotate) === */
+.chakra-segment {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  transform-origin: center center;
+  display: none; /* Hidden by default, shown based on chakra */
+}
+
+/* === Chakra Frame (Top Layer, z-index: 10) === */
 .chakra-frame {
   position: absolute;
   top: 0;
@@ -82,7 +76,7 @@
   width: 140px;
   height: 140px;
   pointer-events: none;
-  z-index: 10; /* Top layer - always visible above everything */
+  z-index: 10;
 }
 
 .bench-portrait-container .chakra-frame {
@@ -91,7 +85,7 @@
 }
 
 /* === Ultimate Ready State (Red Ring) === */
-.chakra-slot.ultimate-ready .chakra-frame {
+.unit-ring.ultimate-ready .chakra-frame {
   filter: drop-shadow(0 0 8px rgba(255, 50, 50, 0.9)) drop-shadow(0 0 16px rgba(255, 50, 50, 0.6));
   animation: ultimateReadyPulse 1s ease-in-out infinite;
 }
@@ -106,7 +100,7 @@
 }
 
 /* === Chakra Gain Flash Effect === */
-.chakra-slot.chakra-gain-flash .chakra-segment {
+.unit-ring.chakra-gain-flash .chakra-segment {
   animation: chakraGainFlash 0.5s ease-out;
 }
 
@@ -255,7 +249,7 @@
 }
 
 /* === Attack Type Selected Feedback === */
-.chakra-slot.attack-selected {
+.unit-ring.attack-selected {
   filter: drop-shadow(0 0 8px rgba(212, 175, 55, 0.8));
   animation: attackSelectedPulse 0.5s ease-out;
 }
@@ -302,14 +296,14 @@
 }
 
 /* === Debug/Development Helper === */
-.chakra-slot.debug {
+.unit-ring.debug {
   outline: 2px dashed rgba(255, 0, 0, 0.5);
 }
 
-.chakra-mask.debug {
+.chakra-container.debug {
   outline: 1px dashed rgba(0, 255, 0, 0.5);
 }
 
-.portrait-clipped.debug {
+.portrait.debug {
   outline: 1px dashed rgba(0, 0, 255, 0.5);
 }


### PR DESCRIPTION
BREAKING CHANGE: Replaced rotation-based system with accumulation

Changes:
- Chakra now accumulates (segments appear) instead of rotating
- Created 5 static arc segments (72° apart each)
- Segments show/hide based on chakra percentage (0-5 visible)
- Each segment rotated statically, not dynamically

Structure changes:
- Renamed .chakra-slot → .unit-ring
- Renamed .portrait-clipped → .portrait
- Removed .chakra-mask (no longer needed)
- Added .chakra-container (holds 5 segments)

Layering (correct order):
1. Portrait (z-index: 1) - bottom
2. Chakra container (z-index: 2) - middle
3. Frame (z-index: 10) - top

Logic:
- 0-20% chakra = 0 segments
- 20-40% chakra = 1 segment
- 40-60% chakra = 2 segments
- 60-80% chakra = 3 segments
- 80-100% chakra = 4 segments
- 100% chakra = 5 segments (full circle)

This matches actual Naruto Blazing behavior.