### PR TITLE
fix: prevent portrait images from overflowing frame boundaries

### DIFF
--- a/css/battle-team-holder.css
+++ b/css/battle-team-holder.css
@@ -44,7 +44,7 @@
   border: 3px solid rgba(160, 127, 80, 0.7);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
   transition: all 0.2s ease;
-  overflow: visible;
+  overflow: hidden;
 }
 
 .active-portrait-container:hover {
@@ -71,7 +71,7 @@
   background: rgba(20, 20, 30, 0.9);
   border: 2px solid rgba(139, 115, 85, 0.6);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
-  overflow: visible;
+  overflow: hidden;
   /* Exact Naruto Blazing stagger positioning */
   left: -25%;  /* X offset: -25% of active width */
   top: 35%;    /* Y offset: +35% of active height */


### PR DESCRIPTION
- Changed overflow from 'visible' to 'hidden' on .active-portrait-container
- Changed overflow from 'visible' to 'hidden' on .bench-portrait-container
- Ensures character portraits are properly contained within their circular frames
- Maintains existing styling (border-radius, object-fit, z-index layering)

This fix resolves the portrait overflow issue where character images extended beyond their decorative frame borders in the battle UI.