### PR TITLE
fix: chakraholder display and character centering issues

### DIFF
--- a/css/battle-chakra-wheel.css
+++ b/css/battle-chakra-wheel.css
@@ -16,10 +16,10 @@
   transform: scale(1.05);
 }
 
-/* Bench units: 100px container */
+/* Bench units: 70px container (50% of active 140px) */
 .bench-portrait-container .unit-ring {
-  width: 100px;
-  height: 100px;
+  width: 70px;
+  height: 70px;
 }
 
 /* === Portrait (Bottom Layer, z-index: 1) === */
@@ -36,8 +36,10 @@
 }
 
 .bench-portrait-container .portrait {
-  width: 88px;
-  height: 88px;
+  width: 64px;
+  height: 64px;
+  top: 3px;
+  left: 3px;
 }
 
 /* === Chakra Container (Middle Layer, z-index: 2) === */
@@ -52,8 +54,10 @@
 }
 
 .bench-portrait-container .chakra-container {
-  width: 88px;
-  height: 88px;
+  width: 64px;
+  height: 64px;
+  top: 3px;
+  left: 3px;
 }
 
 /* === Chakra Segments (Accumulate, Don't Rotate) === */
@@ -80,8 +84,8 @@
 }
 
 .bench-portrait-container .chakra-frame {
-  width: 100px;
-  height: 100px;
+  width: 70px;
+  height: 70px;
 }
 
 /* === Ultimate Ready State (Red Ring) === */

--- a/css/battle-team-holder.css
+++ b/css/battle-team-holder.css
@@ -11,13 +11,15 @@
   display: flex;
   justify-content: center;
   align-items: flex-end;
-  gap: 16px;
-  padding: 16px 20px;
+  gap: 24px; /* Increased gap for larger chakraholders */
+  padding: 20px 32px; /* Increased padding for larger units */
   background: linear-gradient(180deg, rgba(10, 10, 15, 0.5), rgba(10, 10, 15, 0.95));
   border-top: 2px solid rgba(139, 115, 85, 0.6);
   border-radius: 12px 12px 0 0;
   z-index: 100;
   box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.7);
+  width: auto; /* Let flexbox calculate width based on content */
+  min-width: fit-content; /* Ensure it fits all units */
 }
 
 /* === Single Unit Card (contains both active + bench portraits) === */
@@ -37,19 +39,18 @@
 /* === Active Portrait Container (Large) === */
 .active-portrait-container {
   position: relative;
-  width: 90px;
-  height: 90px;
+  width: 140px;
+  height: 140px;
   border-radius: 50%;
-  background: rgba(20, 20, 30, 0.9);
-  border: 3px solid rgba(160, 127, 80, 0.7);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+  background: transparent; /* Let chakraholder frame show */
+  border: none; /* Chakraholder frame provides the border */
+  box-shadow: none; /* Chakraholder frame provides the shadow */
   transition: all 0.2s ease;
-  overflow: hidden;
+  overflow: visible; /* Allow chakraholder to show fully */
 }
 
 .active-portrait-container:hover {
-  border-color: rgba(212, 175, 55, 0.9);
-  box-shadow: 0 6px 16px rgba(212, 175, 55, 0.3);
+  /* Hover effect handled by unit-ring in battle-chakra-wheel.css */
 }
 
 .active-portrait-container img {
@@ -65,16 +66,16 @@
 /* === Bench Portrait Container (Small, staggered nested below active) === */
 .bench-portrait-container {
   position: absolute;
-  width: 40%;  /* 40% of active portrait */
-  height: 40%;
+  width: 56px;  /* Fixed size for bench unit with chakraholder (100px unit-ring scaled down) */
+  height: 56px;
   border-radius: 50%;
-  background: rgba(20, 20, 30, 0.9);
-  border: 2px solid rgba(139, 115, 85, 0.6);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
-  overflow: hidden;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  overflow: visible; /* Allow bench chakraholder to show */
   /* Exact Naruto Blazing stagger positioning */
-  left: -25%;  /* X offset: -25% of active width */
-  top: 35%;    /* Y offset: +35% of active height */
+  left: -20px;  /* X offset: staggered left */
+  bottom: -10px;    /* Y offset: staggered down */
   z-index: 2;
 }
 


### PR DESCRIPTION
Fixed two critical UI issues:

1. Chakraholder not appearing:
   - Increased .active-portrait-container from 90px to 140px to match .unit-ring size
   - Changed overflow from 'hidden' to 'visible' to prevent clipping
   - Removed duplicate border/shadow (chakraholder frame provides these)
   - Adjusted bench unit sizing proportionally (70px unit-ring, 64px portrait)

2. Character centering:
   - Increased team-holder gap from 16px to 24px for larger chakraholders
   - Added width: auto and min-width: fit-content for proper flexbox centering
   - Increased padding from 16px 20px to 20px 32px

The chakraholder frame (140px) and chakra gauge segments now display correctly without being cut off by the portrait container.