### PR TITLE
fix: remove conflicting CSS rules preventing chakraholder display

### DIFF
--- a/css/battle-team-holder.css
+++ b/css/battle-team-holder.css
@@ -53,15 +53,7 @@
   /* Hover effect handled by unit-ring in battle-chakra-wheel.css */
 }
 
-.active-portrait-container img {
-  width: 100%;
-  height: 100%;
-  display: block;
-  border-radius: 50%;
-  object-fit: cover;
-  position: relative;
-  z-index: 1;
-}
+/* Portrait styling is handled by .portrait class in battle-chakra-wheel.css */
 
 /* === Bench Portrait Container (Small, staggered nested below active) === */
 .bench-portrait-container {
@@ -79,15 +71,7 @@
   z-index: 2;
 }
 
-.bench-portrait-container img {
-  width: 100%;
-  height: 100%;
-  display: block;
-  border-radius: 50%;
-  object-fit: cover;
-  position: relative;
-  z-index: 1;
-}
+/* Portrait styling is handled by .portrait class in battle-chakra-wheel.css */
 
 /* === Unit Info (Name, HP) === */
 .unit-info {


### PR DESCRIPTION
Removed `.active-portrait-container img` and `.bench-portrait-container img` rules that were overriding the chakra wheel portrait sizing.

The issue was CSS specificity - these rules applied to ALL img elements inside the containers (including .portrait and .chakra-frame), forcing them to be 100% × 100% of the container size instead of their intended sizes:
- .portrait should be 128px × 128px (active) or 64px × 64px (bench)
- .chakra-frame should be 140px × 140px (active) or 70px × 70px (bench)

Portrait styling is now fully handled by the .portrait class in battle-chakra-wheel.css without interference.