### PR TITLE
Add larger chakra holder frame that properly surrounds portraits

### DIFF
--- a/assets/ui/frames/chakraholder_frame.svg
+++ b/assets/ui/frames/chakraholder_frame.svg
@@ -1,0 +1,24 @@
+<svg width="500" height="500" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="goldGradient" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" style="stop-color:#FFD700;stop-opacity:1" />
+      <stop offset="50%" style="stop-color:#DAA520;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#B8860B;stop-opacity:1" />
+    </radialGradient>
+  </defs>
+
+  <!-- Outer ring -->
+  <circle cx="250" cy="250" r="240" fill="url(#goldGradient)" />
+
+  <!-- Inner shadow ring -->
+  <circle cx="250" cy="250" r="220" fill="#8B5A00" />
+
+  <!-- Inner bright ring -->
+  <circle cx="250" cy="250" r="205" fill="#FFD700" />
+
+  <!-- Cut out center -->
+  <circle cx="250" cy="250" r="190" fill="transparent" />
+
+  <!-- Decorative element at bottom -->
+  <polygon points="250,410 265,430 250,440 235,430" fill="#DAA520" stroke="#8B5A00" stroke-width="2"/>
+</svg>

--- a/chakra-holder-demo.html
+++ b/chakra-holder-demo.html
@@ -13,14 +13,14 @@
             <div class="chakra-container">
                 <img class="chakra-segment" src="assets/ui/gauges/chakra.png" alt="">
             </div>
-            <img class="chakra-frame" src="assets/ui/frames/chakraholder_icon.png" alt="">
+            <img class="chakra-frame" src="assets/ui/frames/chakraholder_frame.svg" alt="">
 
             <div class="mini-unit-ring">
                 <img class="portrait" src="" alt="">
                 <div class="chakra-container">
                     <img class="chakra-segment" src="assets/ui/gauges/chakra.png" alt="">
                 </div>
-                <img class="chakra-frame" src="assets/ui/frames/chakraholder_icon.png" alt="">
+                <img class="chakra-frame" src="assets/ui/frames/chakraholder_frame.svg" alt="">
             </div>
         </div>
         <div class="unit-name"></div>

--- a/css/chakra-holder.css
+++ b/css/chakra-holder.css
@@ -13,16 +13,16 @@ body {
 
 .unit-ring {
     position: relative;
-    width: 140px;
-    height: 140px;
+    width: 200px;
+    height: 200px;
 }
 
 .unit-ring > .portrait {
     position: absolute;
-    width: 128px;
-    height: 128px;
-    top: 6px;
-    left: 6px;
+    width: 160px;
+    height: 160px;
+    top: 20px;
+    left: 20px;
     border-radius: 50%;
     clip-path: circle(50%);
     object-fit: cover;
@@ -31,10 +31,10 @@ body {
 
 .unit-ring > .chakra-container {
     position: absolute;
-    width: 128px;
-    height: 128px;
-    top: 6px;
-    left: 6px;
+    width: 160px;
+    height: 160px;
+    top: 20px;
+    left: 20px;
     overflow: hidden;
     border-radius: 50%;
     z-index: 2;
@@ -51,30 +51,31 @@ body {
 
 .unit-ring > .chakra-frame {
     position: absolute;
-    width: 140px;
-    height: 140px;
+    width: 200px;
+    height: 200px;
     top: 0;
     left: 0;
     z-index: 10;
     pointer-events: none;
+    object-fit: contain;
 }
 
 .mini-unit-ring {
     position: absolute;
-    width: 140px;
-    height: 140px;
-    bottom: -10px;
-    left: -10px;
-    transform: scale(0.43);
+    width: 200px;
+    height: 200px;
+    bottom: -20px;
+    left: -20px;
+    transform: scale(0.4);
     transform-origin: center center;
 }
 
 .mini-unit-ring > .portrait {
     position: absolute;
-    width: 128px;
-    height: 128px;
-    top: 6px;
-    left: 6px;
+    width: 160px;
+    height: 160px;
+    top: 20px;
+    left: 20px;
     border-radius: 50%;
     clip-path: circle(50%);
     object-fit: cover;
@@ -83,10 +84,10 @@ body {
 
 .mini-unit-ring > .chakra-container {
     position: absolute;
-    width: 128px;
-    height: 128px;
-    top: 6px;
-    left: 6px;
+    width: 160px;
+    height: 160px;
+    top: 20px;
+    left: 20px;
     overflow: hidden;
     border-radius: 50%;
     z-index: 2;
@@ -103,12 +104,13 @@ body {
 
 .mini-unit-ring > .chakra-frame {
     position: absolute;
-    width: 140px;
-    height: 140px;
+    width: 200px;
+    height: 200px;
     top: 0;
     left: 0;
     z-index: 10;
     pointer-events: none;
+    object-fit: contain;
 }
 
 .unit-name {


### PR DESCRIPTION
- Created chakraholder_frame.svg with full-size golden ring frame
- Increased unit ring size from 140x140 to 200x200
- Portrait size increased from 128x128 to 160x160
- Frame now properly surrounds and frames the unit portraits
- Mini unit ring scales to 40% (80x80 visual size)
- Updated HTML to use new SVG frame instead of small icon