### PR TITLE
Fix chakra z-index layering to display on top of frame

### DIFF
--- a/chakra-holder-demo.html
+++ b/chakra-holder-demo.html
@@ -13,14 +13,14 @@
             <div class="chakra-container">
                 <img class="chakra-segment" src="assets/ui/gauges/chakra.png" alt="">
             </div>
-            <img class="chakra-frame" src="assets/ui/frames/chakraholder_frame.svg" alt="">
+            <img class="chakra-frame" src="assets/ui/frames/chakraholder_icon.png" alt="">
 
             <div class="mini-unit-ring">
                 <img class="portrait" src="" alt="">
                 <div class="chakra-container">
                     <img class="chakra-segment" src="assets/ui/gauges/chakra.png" alt="">
                 </div>
-                <img class="chakra-frame" src="assets/ui/frames/chakraholder_frame.svg" alt="">
+                <img class="chakra-frame" src="assets/ui/frames/chakraholder_icon.png" alt="">
             </div>
         </div>
         <div class="unit-name"></div>

--- a/css/chakra-holder.css
+++ b/css/chakra-holder.css
@@ -37,7 +37,7 @@ body {
     left: 20px;
     overflow: hidden;
     border-radius: 50%;
-    z-index: 2;
+    z-index: 10;
 }
 
 .unit-ring > .chakra-container > .chakra-segment {
@@ -55,7 +55,7 @@ body {
     height: 200px;
     top: 0;
     left: 0;
-    z-index: 10;
+    z-index: 2;
     pointer-events: none;
     object-fit: contain;
 }
@@ -90,7 +90,7 @@ body {
     left: 20px;
     overflow: hidden;
     border-radius: 50%;
-    z-index: 2;
+    z-index: 10;
 }
 
 .mini-unit-ring > .chakra-container > .chakra-segment {
@@ -108,7 +108,7 @@ body {
     height: 200px;
     top: 0;
     left: 0;
-    z-index: 10;
+    z-index: 2;
     pointer-events: none;
     object-fit: contain;
 }


### PR DESCRIPTION
- Swapped z-index: chakra-container now 10, chakra-frame now 2
- Chakra gauge now properly displays on top of holder frame
- Reverted to using original chakraholder_icon.png
- Maintains original PNG dimensions as requested