### PR TITLE
fix: increase attack radius from 200 to 400 pixels and improve debug …

### DIFF
--- a/js/battle/battle-drag.js
+++ b/js/battle/battle-drag.js
@@ -401,7 +401,7 @@
         color = "jutsu";
       } else {
         shape = "circle";
-        args = { radius: 200 }; // Increased from 100 to 200 for better targeting
+        args = { radius: 400 }; // Increased to 400 for much more forgiving targeting
         color = "jutsu";
       }
 
@@ -425,10 +425,10 @@
         args = skills.ultimate.data?.shapeArgs || { radius: 260, angleDeg: 90 };
       } else {
         shape = "circle";
-        args = { radius: 200 }; // Increased from 100 to 200 for better targeting
+        args = { radius: 400 }; // Increased to 400 for much more forgiving targeting
       }
 
-      console.log(`[Drag] findUnitsInRange: center=(${x.toFixed(1)}, ${y.toFixed(1)}), shape=${shape}, args=`, args);
+      console.log(`[Drag] findUnitsInRange: center=(${x.toFixed(1)}, ${y.toFixed(1)}), shape=${shape}, radius=${args.radius || args.w || 'N/A'}`);
 
       const targets = [];
       for (const unit of core.enemyTeam) {


### PR DESCRIPTION
…logging

- Quadrupled attack radius (100 -> 200 -> 400) for much more forgiving targeting
- User was failing at 219-533 pixel distances with 200px radius
- Only succeeded at 166-195 pixel distances (very precise requirement)
- Updated both findUnitsInRange() and showDragTargetingPreview() to use 400px
- Improved debug logging to show actual radius value instead of generic "Object"
- Visual circle and actual targeting now both use same 400px radius