### PR TITLE
feat: optimize bench chakra ring sizing and positioning

### DIFF
--- a/css/battle-chakra-wheel.css
+++ b/css/battle-chakra-wheel.css
@@ -18,10 +18,10 @@
   transform: scale(1.05);
 }
 
-/* Bench units (70×70) */
+/* Bench units (60×60 - smaller version for clarity) */
 .bench-portrait-container .unit-ring {
-  width: 70px;
-  height: 70px;
+  width: 60px;
+  height: 60px;
 }
 
 /* =========================================
@@ -39,12 +39,12 @@
     z-index: 1;
 }
 
-/* Bench portrait: perfectly centered in 70×70 holder */
+/* Bench portrait: perfectly centered in 60×60 holder */
 .bench-portrait-container .portrait {
-  top: 3px;
-  left: 3px;
-  width: 64px;
-  height: 64px;
+  top: 2px;
+  left: 2px;
+  width: 56px;
+  height: 56px;
 }
 
 /* =========================================
@@ -63,10 +63,10 @@
 }
 
 .bench-portrait-container .chakra-container {
-  top: 3px;
-  left: 3px;
-  width: 64px;
-  height: 64px;
+  top: 2px;
+  left: 2px;
+  width: 56px;
+  height: 56px;
 }
 
 /* Chakra segments - single rotating arc */
@@ -95,12 +95,12 @@
     z-index: 10;
 }
 
-/* Bench frame = 70×70 */
+/* Bench frame = 60×60 scaled */
 .bench-portrait-container .chakra-frame {
-  top: -34px;
-  left: -34px;
-  width: 140px !important;
-  height: 140px !important;
+  top: -60px;
+  left: -60px;
+  width: 180px !important;
+  height: 180px !important;
   object-fit: fill !important;
 }
 

--- a/css/battle-team-holder.css
+++ b/css/battle-team-holder.css
@@ -58,16 +58,16 @@
 /* === Bench Portrait Container (Small, staggered nested below active) === */
 .bench-portrait-container {
   position: absolute;
-  width: 56px;  /* Fixed size for bench unit with chakraholder (100px unit-ring scaled down) */
-  height: 56px;
+  width: 60px;  /* Smaller chakra ring for bench (60% of active 100px) */
+  height: 60px;
   border-radius: 50%;
   background: transparent;
   border: none;
   box-shadow: none;
   overflow: visible; /* Allow bench chakraholder to show */
-  /* Exact Naruto Blazing stagger positioning */
-  left: -20px;  /* X offset: staggered left */
-  bottom: -10px;    /* Y offset: staggered down */
+  /* Lower left positioning relative to active */
+  left: -25px;  /* X offset: positioned to the left */
+  bottom: -15px;  /* Y offset: positioned at the bottom */
   z-index: 2;
 }
 


### PR DESCRIPTION
Improved bench chakra rings to be more clearly visible as smaller versions positioned at lower left of active rings:
- Scaled bench unit-ring to 60×60px (from 70×70px) for better size differentiation
- Proportionally scaled all bench components (portrait: 56×56px, chakra-container: 56×56px, frame: 180×180px)
- Enhanced lower-left positioning (left: -25px, bottom: -15px)
- Active chakra holders remain completely unchanged

Changes:
- css/battle-chakra-wheel.css: Updated bench-portrait-container component sizing
- css/battle-team-holder.css: Adjusted bench container size and position