### PR TITLE
fix: remove duplicate bottom bar and standardize summon.html navigation

### DIFF
--- a/css/summon.css
+++ b/css/summon.css
@@ -502,64 +502,7 @@ body.page-summon {
   padding: 6px 10px;
 }
 
-/* Bottom Navigation - CIRCULAR ICONS */
-.bottom-nav {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 80px;
-  background: rgba(40, 40, 40, 0.85);
-  border-top: 1px solid rgba(255, 255, 255, 0.2);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 30px;
-  z-index: 100;
-  backdrop-filter: blur(15px);
-  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.5);
-}
-
-.nav-btn {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  background: none;
-  border: none;
-  color: #666;
-  font-size: 11px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  padding: 8px 16px;
-}
-
-.nav-btn:hover,
-.nav-btn.active {
-  color: #fff;
-}
-
-.nav-btn img {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.2);
-  background: rgba(0, 0, 0, 0.5);
-  padding: 8px;
-  opacity: 0.6;
-  transition: all 0.2s ease;
-}
-
-.nav-btn:hover img,
-.nav-btn.active img {
-  opacity: 1;
-  border-color: rgba(255, 255, 255, 0.6);
-  background: rgba(0, 0, 0, 0.7);
-  transform: scale(1.1);
-}
+/* Bottom bar styles are now handled by css/background.css */
 
 /* Summon Modal */
 .summon-modal {

--- a/summon.html
+++ b/summon.html
@@ -5,6 +5,7 @@
   <title>Summon — Blazing</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="css/summon.css" />
+  <link rel="stylesheet" href="css/background.css" />
   <link rel="stylesheet" href="css/summon-dev-panel.css" />
   <link rel="stylesheet" href="css/summon-banner-carousel.css" />
   <link rel="stylesheet" href="css/summon-results.css" />
@@ -127,34 +128,6 @@
       <span>Drop Rate</span>
     </button>
   </div>
-
-  <!-- Bottom Navigation -->
-  <nav class="bottom-nav">
-    <button class="nav-btn" onclick="window.location.href='index.html'">
-      <img src="assets/icons/village_icon.png" alt="Villages">
-      <span>VILLAGES</span>
-    </button>
-    <button class="nav-btn" onclick="window.location.href='teams.html'">
-      <img src="assets/icons/teams_icon.png" alt="Teams">
-      <span>TEAMS</span>
-    </button>
-    <button class="nav-btn active">
-      <img src="assets/icons/summon_icon.png" alt="Summon">
-      <span>SUMMON</span>
-    </button>
-    <button class="nav-btn" onclick="window.location.href='characters.html'">
-      <img src="assets/icons/shop_icon.png" alt="Shop">
-      <span>SHOP</span>
-    </button>
-    <button class="nav-btn" onclick="window.location.href='missions.html'">
-      <img src="assets/icons/friends_icon.png" alt="Friends">
-      <span>FRIENDS</span>
-    </button>
-    <button class="nav-btn">
-      <img src="assets/icons/other_icon.png" alt="Other">
-      <span>OTHER</span>
-    </button>
-  </nav>
 
   <!-- Summon Result Modal -->
   <div id="summon-modal" class="summon-modal hidden">


### PR DESCRIPTION
Resolved duplicate bottom navigation bars in summon.html:

1. Removed Duplicate Navigation:
   - Deleted old floating .bottom-nav section (lines 131-157)
   - Kept standardized .bottom-bar with proper structure
   - Eliminated visual conflict between two overlapping navigation bars

2. Standardized Styling:
   - Added css/background.css import to summon.html
   - Removed obsolete .bottom-nav and .nav-btn styles from summon.css
   - Bottom bar now uses consistent styling across all pages

3. Navigation Order & Aesthetics:
   - Button order: Village → Characters → Fusion → Teams → Summon → Missions → Shop
   - Matches order and appearance of index.html, characters.html, teams.html, etc.
   - Uses circular icon buttons with proper hover effects
   - Proper z-index layering (z-index: 100)

4. Files Modified:
   - summon.html: Removed duplicate nav, added background.css import
   - css/summon.css: Removed old bottom-nav styles

Bottom navigation bar now consistent across entire application.