### PR TITLE
feat: enhance dupe feeding UI to show unlimited ability unlock progress

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -721,6 +721,7 @@ body.page-characters {
 }
 
 .dupe-card {
+  position: relative;
   background: rgba(0,0,0,0.4);
   border: 1px solid rgba(255,215,120,0.1);
   border-radius: 8px;

--- a/js/characters.js
+++ b/js/characters.js
@@ -351,12 +351,32 @@
       return;
     }
 
+    // Get ability unlock progress
+    const unlockedCount = (mainInst.unlockedAbilities || []).length;
+    const maxAbilities = character.abilities ? character.abilities.length : 0;
+    const remainingAbilities = maxAbilities - unlockedCount;
+
+    // Update modal title with progress
+    const modalTitle = document.querySelector('.dupe-modal-title');
+    if (modalTitle) {
+      modalTitle.innerHTML = `
+        Select Duplicate to Feed
+        <div style="font-size: 14px; color: #d9b362; margin-top: 8px; font-weight: normal;">
+          Abilities Unlocked: ${unlockedCount}/${maxAbilities}
+          ${remainingAbilities > 0 ? `<br><span style="color: #b8985f;">Feed ${remainingAbilities} more duplicate${remainingAbilities === 1 ? '' : 's'} to unlock all abilities</span>` : '<br><span style="color: #62d98f;">All abilities unlocked!</span>'}
+        </div>
+      `;
+    }
+
     // Render dupe grid
-    DUPE_GRID.innerHTML = dupes.map(dupe => {
+    DUPE_GRID.innerHTML = dupes.map((dupe, index) => {
       const tier = dupe.tierCode || minTier(character);
       const art = resolveTierArt(character, tier);
+      const willUnlock = index < remainingAbilities ?
+        `<div style="position:absolute; top:4px; right:4px; background:rgba(212,175,55,0.9); color:#111; padding:2px 6px; border-radius:4px; font-size:10px; font-weight:600;">WILL UNLOCK</div>` : '';
       return `
         <div class="dupe-card" data-uid="${dupe.uid}">
+          ${willUnlock}
           <img class="dupe-card-portrait" src="${safeStr(art.portrait, character.portrait)}" alt="${character.name}"
                onerror="this.onerror=null;this.src='assets/characters/_common/silhouette.png';" />
           <div class="dupe-card-level">Lv ${dupe.level || 1}</div>
@@ -586,6 +606,23 @@
       const unlockedCount = (inst.unlockedAbilities || []).length;
       const maxAbilities = c.abilities ? c.abilities.length : 0;
       const allUnlocked = unlockedCount >= maxAbilities;
+
+      // Update button text to show progress
+      if (hasAbilities) {
+        BTN_FEEDDUPE.textContent = `Latent Awaken (${unlockedCount}/${maxAbilities})`;
+
+        // Add tooltip hint
+        if (allUnlocked) {
+          BTN_FEEDDUPE.title = "All abilities unlocked!";
+        } else if (!hasDupes) {
+          BTN_FEEDDUPE.title = "No duplicates available. Summon more copies to unlock abilities.";
+        } else {
+          BTN_FEEDDUPE.title = `Feed duplicates to unlock abilities. ${maxAbilities - unlockedCount} remaining.`;
+        }
+      } else {
+        BTN_FEEDDUPE.textContent = "Latent Awaken";
+        BTN_FEEDDUPE.title = "This character has no abilities to unlock";
+      }
 
       BTN_FEEDDUPE.disabled = !hasDupes || !hasAbilities || allUnlocked;
 


### PR DESCRIPTION
Clarified that players can feed multiple dupes (not limited to 2):

1. Button Progress Display:
   - "Latent Awaken" button now shows "(X/Y)" progress
   - Example: "Latent Awaken (3/7)" shows 3 of 7 abilities unlocked
   - Tooltip messages explain remaining dupes needed

2. Dupe Selector Modal Improvements:
   - Modal title shows "Abilities Unlocked: X/Y"
   - Shows how many more dupes needed to unlock all abilities
   - "WILL UNLOCK" badge on dupe cards that will unlock new abilities
   - Color-coded messages (gold for progress, green for complete)

3. Enhanced Tooltips:
   - All unlocked: "All abilities unlocked!"
   - No dupes: "No duplicates available. Summon more copies to unlock abilities."
   - Ready to feed: "Feed duplicates to unlock abilities. X remaining."

4. Visual Indicators:
   - Gold "WILL UNLOCK" badge appears on dupes that grant new abilities
   - Clear progress tracking in modal header
   - Position relative on dupe-card for badge positioning

System already supported unlimited dupe feeding - UI now makes this clear! Players can feed up to 7 dupes (or character's total ability count).