### PR TITLE
fix: add missing 5 abilities to Taki & Mitsuha for full dupe feeding

### DIFF
--- a/data/characters.json
+++ b/data/characters.json
@@ -510,6 +510,26 @@
     {
       "name": "Celestial Resonance",
       "description": "Boosts Ultimate damage by 20% and reduces its cooldown by 1 when used after an ally's Secret Technique."
+    },
+    {
+      "name": "Temporal Strike",
+      "description": "Increases ATK by 250 and boosts combo damage by 15%."
+    },
+    {
+      "name": "Healing Threads",
+      "description": "Restores 200 HP at the start of each turn and boosts healing received by 20%."
+    },
+    {
+      "name": "Bonds of Protection",
+      "description": "Increases max HP by 500 and grants damage reduction of 10% when HP is above 70%."
+    },
+    {
+      "name": "Comet's Endurance",
+      "description": "Boosts DEF by 300 and reduces damage from critical hits by 25%."
+    },
+    {
+      "name": "Time Acceleration",
+      "description": "Increases SPD by 80 and grants 20% chance to take an extra turn after attacking."
     }
   ]
 }


### PR DESCRIPTION
Fixed Latent Awaken limit from 2/2 to 7/7 for Taki & Mitsuha character:

Problem:
- Character has 7 passive icons defined
- Only 2 abilities in abilities array
- System stopped at "Latent Awaken (2/2)"
- Could not unlock remaining 5 passives (Health Up, Speed Up, etc.)

Solution:
- Added 5 new abilities to match the 7 passive icons
- New abilities unlocked by feeding dupes:
  1. Fate Synchronization (existing)
  2. Celestial Resonance (existing)
  3. Temporal Strike (ATK +250, combo damage +15%)
  4. Healing Threads (200 HP/turn, healing +20%)
  5. Bonds of Protection (HP +500, 10% damage reduction)
  6. Comet's Endurance (DEF +300, crit damage -25%)
  7. Time Acceleration (SPD +80, 20% extra turn chance)

Abilities now match passive icons:
- passiveIcons: ["atk_up", "heal_up", "heal_up", "def_up", "speed_up", "speed_up", "speed_up"]
- abilities: 7 total (was 2, now 7)

Players can now feed 7 duplicates to unlock all abilities!