### PR TITLE
feat: add Awakening tab, change LB color to red, and widen modal

### DIFF
--- a/characters.html
+++ b/characters.html
@@ -32,6 +32,7 @@
 
         <div class="char-tabs">
           <button class="tab-btn is-active" data-tab="status">Status</button>
+          <button class="tab-btn" data-tab="awakening">Awakening</button>
           <button class="tab-btn" data-tab="skills">Ninjutsu</button>
           <button class="tab-btn" data-tab="support">F/B Skills</button>
           <button class="tab-btn" data-tab="abilities">Abilities</button>
@@ -40,6 +41,9 @@
         <div class="tab-panels">
           <section class="tab-panel is-active" id="tab-status">
             <div class="stats-grid" id="char-stats"></div>
+          </section>
+
+          <section class="tab-panel" id="tab-awakening">
             <div class="growth-ops">
               <div class="level-strip">
                 <span class="level-badge">

--- a/css/characters.css
+++ b/css/characters.css
@@ -501,7 +501,7 @@ body.page-characters {
   display: grid;
   grid-template-columns: 1fr 1fr;       /* art | info */
   gap: 18px;
-  width: min(100%, 980px);
+  width: min(100%, 1150px);             /* increased from 980px to prevent scrollbar */
   max-height: 82vh;                     /* stays inside viewport */
   padding: 16px;
   background: #131318;
@@ -567,16 +567,16 @@ body.page-characters {
   font-size: 15px;
   font-weight: 600;
   color: #fff;
-  background: linear-gradient(180deg, #b362d9 0%, #822ca7 100%);
-  border: 1px solid rgba(179, 98, 217, 0.4);
+  background: linear-gradient(180deg, #d94242 0%, #8b1a1a 100%);
+  border: 1px solid rgba(217, 66, 66, 0.4);
   border-radius: 8px;
   cursor: pointer;
   transition: all .2s ease;
-  box-shadow: 0 4px 12px rgba(130, 44, 167, 0.3);
+  box-shadow: 0 4px 12px rgba(139, 26, 26, 0.3);
 }
 .btn-limitbreak:hover:not(:disabled) {
-  background: linear-gradient(180deg, #c47ee6 0%, #9642b8 100%);
-  box-shadow: 0 6px 16px rgba(130, 44, 167, 0.5);
+  background: linear-gradient(180deg, #e65555 0%, #a02020 100%);
+  box-shadow: 0 6px 16px rgba(139, 26, 26, 0.5);
   transform: translateY(-1px);
 }
 .btn-limitbreak:disabled {
@@ -589,15 +589,15 @@ body.page-characters {
 .limitbreak-info {
   margin-top: 12px;
   padding: 10px 14px;
-  background: rgba(179, 98, 217, 0.08);
-  border: 1px solid rgba(179, 98, 217, 0.2);
+  background: rgba(217, 66, 66, 0.08);
+  border: 1px solid rgba(217, 66, 66, 0.2);
   border-radius: 8px;
   font-size: 13px;
 }
 
 .lb-level {
   font-weight: 600;
-  color: #b362d9;
+  color: #d94242;
   margin-bottom: 6px;
 }
 


### PR DESCRIPTION
1. New Awakening Tab:
   - Added "Awakening" tab between Status and Ninjutsu
   - Moved all growth operations to Awakening tab:
     * Level Up button
     * Latent Awaken button (with progress display) * Remove Copy button * Awaken button * Limit Break button
   - Status tab now shows only character stats (cleaner)
   - Tab order: Status → Awakening → Ninjutsu → F/B Skills → Abilities

2. Limit Break Color Change:
   - Changed from purple gradient to dark red gradient
   - Button: #d94242 to #8b1a1a (dark red)
   - Hover: #e65555 to #a02020 (lighter red)
   - Info box: Updated border and background to red theme
   - LB level text: Changed from purple (#b362d9) to red (#d94242)

3. Modal Width Increase:
   - Increased from 980px to 1150px
   - Prevents horizontal scrollbar in Abilities tab
   - Abilities now display without cutoff
   - All tabs have more breathing room

All character info tabs now display content properly without scrolling!