### PR TITLE
remove: chakra stat from character displays and calculations

### DIFF
--- a/js/characters.js
+++ b/js/characters.js
@@ -271,16 +271,14 @@
         <div class="stat-row"><span class="stat-label">Health</span><span class="stat-value">${stats.hp ?? "-"}</span></div>
         <div class="stat-row"><span class="stat-label">Attack</span><span class="stat-value">${stats.atk ?? "-"}</span></div>
         <div class="stat-row"><span class="stat-label">Defense</span><span class="stat-value">${stats.def ?? "-"}</span></div>
-        <div class="stat-row"><span class="stat-label">Speed</span><span class="stat-value">${stats.speed ?? "-"}</span></div>
-        <div class="stat-row"><span class="stat-label">Chakra</span><span class="stat-value">${stats.chakra ?? "-"}</span></div>`;
+        <div class="stat-row"><span class="stat-label">Speed</span><span class="stat-value">${stats.speed ?? "-"}</span></div>`;
     } else {
       const s = c.statsBase || {};
       STATS_WRAP.innerHTML = `
         <div class="stat-row"><span class="stat-label">Health</span><span class="stat-value">${s.hp ?? "-"}</span></div>
         <div class="stat-row"><span class="stat-label">Attack</span><span class="stat-value">${s.atk ?? "-"}</span></div>
         <div class="stat-row"><span class="stat-label">Defense</span><span class="stat-value">${s.def ?? "-"}</span></div>
-        <div class="stat-row"><span class="stat-label">Speed</span><span class="stat-value">${s.speed ?? "-"}</span></div>
-        <div class="stat-row"><span class="stat-label">Chakra</span><span class="stat-value">${s.chakra ?? "-"}</span></div>`;
+        <div class="stat-row"><span class="stat-label">Speed</span><span class="stat-value">${s.speed ?? "-"}</span></div>`;
     }
 
     let cap = tierCap(c, tier);

--- a/js/limit-break.js
+++ b/js/limit-break.js
@@ -26,8 +26,7 @@
     hp: 0.02,      // 2% per level
     atk: 0.025,    // 2.5% per level
     def: 0.02,     // 2% per level
-    speed: 0.015,  // 1.5% per level
-    chakra: 0.01   // 1% per level
+    speed: 0.015   // 1.5% per level
   };
 
   // Load limit break costs from JSON
@@ -164,14 +163,13 @@
   // Compute stat bonuses from limit breaks
   function computeLimitBreakBonus(limitBreakLevel) {
     const lb = Number(limitBreakLevel) || 0;
-    if (lb <= 0) return { hp: 0, atk: 0, def: 0, speed: 0, chakra: 0 };
+    if (lb <= 0) return { hp: 0, atk: 0, def: 0, speed: 0 };
 
     return {
       hp: lb * LIMIT_BREAK_BONUS_PER_LEVEL.hp,
       atk: lb * LIMIT_BREAK_BONUS_PER_LEVEL.atk,
       def: lb * LIMIT_BREAK_BONUS_PER_LEVEL.def,
-      speed: lb * LIMIT_BREAK_BONUS_PER_LEVEL.speed,
-      chakra: lb * LIMIT_BREAK_BONUS_PER_LEVEL.chakra
+      speed: lb * LIMIT_BREAK_BONUS_PER_LEVEL.speed
     };
   }
 
@@ -186,8 +184,7 @@
       hp: Math.round(baseStats.hp * (1 + bonus.hp)),
       atk: Math.round(baseStats.atk * (1 + bonus.atk)),
       def: Math.round(baseStats.def * (1 + bonus.def)),
-      speed: Math.round(baseStats.speed * (1 + bonus.speed)),
-      chakra: Math.round(baseStats.chakra * (1 + bonus.chakra))
+      speed: Math.round(baseStats.speed * (1 + bonus.speed))
     };
   }
 

--- a/js/progression.js
+++ b/js/progression.js
@@ -37,7 +37,7 @@
 
   // Defaults if a character doesn't specify growth curves or power weights
   const DEFAULT_GROWTH = 1.0; // linear
-  const DEFAULT_WEIGHTS = { hp:0.35, atk:0.35, def:0.15, speed:0.10, chakra:0.05 };
+  const DEFAULT_WEIGHTS = { hp:0.35, atk:0.35, def:0.15, speed:0.15 };
 
   /* ===============
    * Small helpers
@@ -76,8 +76,7 @@
       (stats.hp    || 0) * (weights.hp    ?? 0.35) +
       (stats.atk   || 0) * (weights.atk   ?? 0.35) +
       (stats.def   || 0) * (weights.def   ?? 0.15) +
-      (spdTerm          ) * (weights.speed ?? 0.10) * 30 +
-      (stats.chakra|| 0) * (weights.chakra?? 0.05) * 40
+      (spdTerm          ) * (weights.speed ?? 0.15) * 30
     );
   }
 
@@ -152,8 +151,7 @@
     if (!max) {
       const fixed = {
         hp: base.hp|0, atk: base.atk|0, def: base.def|0,
-        speed: base.speed ?? base.spd ?? 0,
-        chakra: base.chakra ?? base.cost ?? 0
+        speed: base.speed ?? base.spd ?? 0
       };
       return { stats: fixed, power: computePower(fixed, c?.powerWeights), cap, tier: clampedTier, minCode, maxCode, scaleApplied: 1 };
     }
@@ -166,8 +164,7 @@
       hp:     Math.round((base.hp||0)     + (max.hp||0     - (base.hp||0))     * fracToMax),
       atk:    Math.round((base.atk||0)    + (max.atk||0    - (base.atk||0))    * fracToMax),
       def:    Math.round((base.def||0)    + (max.def||0    - (base.def||0))    * fracToMax),
-      speed:  Math.round(((base.speed??base.spd)||0) + (((max.speed??max.spd)||0) - ((base.speed??base.spd)||0)) * fracToMax),
-      chakra: Math.round(((base.chakra??base.cost)||0) + (((max.chakra??max.cost)||0) - ((base.chakra??base.cost)||0)) * fracToMax)
+      speed:  Math.round(((base.speed??base.spd)||0) + (((max.speed??max.spd)||0) - ((base.speed??base.spd)||0)) * fracToMax)
     };
 
     // Per-stat growth
@@ -178,8 +175,7 @@
       hp:     statAtLevel(base.hp||0,     target.hp||0,     L, cap, curveFor('hp')),
       atk:    statAtLevel(base.atk||0,    target.atk||0,    L, cap, curveFor('atk')),
       def:    statAtLevel(base.def||0,    target.def||0,    L, cap, curveFor('def')),
-      speed:  statAtLevel((base.speed??base.spd)||0,  target.speed||0,  L, cap, curveFor('speed')),
-      chakra: statAtLevel((base.chakra??base.cost)||0, target.chakra||0, L, cap, curveFor('chakra'))
+      speed:  statAtLevel((base.speed??base.spd)||0,  target.speed||0,  L, cap, curveFor('speed'))
     };
 
     // Lore normalization (mild)
@@ -200,8 +196,7 @@
         hp:     Math.round(eff.hp     * clampedScale),
         atk:    Math.round(eff.atk    * clampedScale),
         def:    Math.round(eff.def    * clampedScale),
-        speed:  Math.round(eff.speed  * clampedScale),
-        chakra: Math.round(eff.chakra * clampedScale)
+        speed:  Math.round(eff.speed  * clampedScale)
       };
       return { stats: eff, power: computePower(eff, weights), cap, tier: clampedTier, minCode, maxCode, scaleApplied: clampedScale };
     }

--- a/js/team_manager.js
+++ b/js/team_manager.js
@@ -451,7 +451,7 @@
     previewStars.innerHTML = renderStars(starsFromTier(tier));
 
     // Stats
-    let stats = { hp: 0, atk: 0, def: 0, speed: 0, chakra: 0 };
+    let stats = { hp: 0, atk: 0, def: 0, speed: 0 };
     if (window.Progression?.computeEffectiveStatsLoreTier) {
       const result = window.Progression.computeEffectiveStatsLoreTier(
         char, inst.level, tier, { normalize: true }
@@ -459,7 +459,7 @@
       stats = result.stats;
     } else {
       const src = pickStats(char, DISPLAY_MODE);
-      stats = { hp: src.hp || 0, atk: src.atk || 0, def: src.def || 0, speed: src.speed || 0, chakra: src.chakra || 0 };
+      stats = { hp: src.hp || 0, atk: src.atk || 0, def: src.def || 0, speed: src.speed || 0 };
     }
 
     previewStats.innerHTML = `
@@ -467,7 +467,6 @@
       <div class="preview-stat"><span class="preview-stat-label">Attack</span><span class="preview-stat-value">${safeNum(stats.atk,0).toLocaleString()}</span></div>
       <div class="preview-stat"><span class="preview-stat-label">Defense</span><span class="preview-stat-value">${safeNum(stats.def,0).toLocaleString()}</span></div>
       <div class="preview-stat"><span class="preview-stat-label">Speed</span><span class="preview-stat-value">${safeNum(stats.speed,0)}</span></div>
-      <div class="preview-stat"><span class="preview-stat-label">Chakra</span><span class="preview-stat-value">${safeNum(stats.chakra,0)}</span></div>
     `;
 
     previewModal.classList.add("open");


### PR DESCRIPTION
- Removed chakra from character info modal (characters.js)
- Removed chakra from team manager preview (team_manager.js)
- Removed chakra from limit break bonuses (limit-break.js)
- Removed chakra from progression stat calculations (progression.js)
- Rebalanced stat weights (speed increased from 0.10 to 0.15)