### PR TITLE
fix: sync currency between index.html and summon.html

### DIFF
--- a/js/summon/summon-dev-panel.js
+++ b/js/summon/summon-dev-panel.js
@@ -96,14 +96,13 @@ class DevPanel {
   }
 
   addCurrency(type, amount) {
-    if (!window.Currency) {
-      console.warn('Currency system not loaded');
+    if (!window.Resources) {
+      console.warn('Resources system not loaded');
       return;
     }
 
-    const key = type === 'pearls' ? window.Currency.keys.pearls : window.Currency.keys.coins;
-    const current = window.Currency.get(key, 0);
-    window.Currency.set(key, current + amount);
+    const key = type === 'pearls' ? 'ninja_pearls' : 'ryo';
+    window.Resources.add(key, amount);
 
     // Update display
     if (window.SummonUI) {
@@ -115,11 +114,12 @@ class DevPanel {
   }
 
   resetCurrency() {
-    if (!window.Currency) return;
+    if (!window.Resources) return;
 
     if (confirm('Reset all currency to 0?')) {
-      window.Currency.set(window.Currency.keys.pearls, 0);
-      window.Currency.set(window.Currency.keys.coins, 0);
+      window.Resources.set('ninja_pearls', 0);
+      window.Resources.set('ryo', 0);
+      window.Resources.set('shinobites', 0);
 
       // Update display
       if (window.SummonUI) {

--- a/js/summon/summon-ui.js
+++ b/js/summon/summon-ui.js
@@ -61,19 +61,19 @@ class SummonUIController {
     // Modal overlay click to close
     this.elements.modal?.querySelector('.modal-overlay')?.addEventListener('click', () => this.hideResults());
 
-    // Listen for currency changes
-    window.addEventListener('currencyChanged', () => this.updateCurrencyDisplay());
+    // Refresh currency display every 2 seconds to catch changes from other pages
+    setInterval(() => this.updateCurrencyDisplay(), 2000);
   }
 
   updateCurrencyDisplay() {
-    const pearls = window.Currency?.get(window.Currency?.keys?.pearls, 0) || 0;
-    const coins = window.Currency?.get(window.Currency?.keys?.coins, 0) || 0;
+    const pearls = window.Resources?.get('ninja_pearls') || 0;
+    const ryo = window.Resources?.get('ryo') || 0;
 
     if (this.elements.playerPearls) {
-      this.elements.playerPearls.textContent = pearls;
+      this.elements.playerPearls.textContent = pearls.toLocaleString();
     }
     if (this.elements.playerCoins) {
-      this.elements.playerCoins.textContent = coins;
+      this.elements.playerCoins.textContent = ryo.toLocaleString();
     }
 
     // Update button states
@@ -161,7 +161,7 @@ class SummonUIController {
   }
 
   async handleSingleSummon() {
-    const pearls = window.Currency?.get(window.Currency?.keys?.pearls, 0) || 0;
+    const pearls = window.Resources?.get('ninja_pearls') || 0;
 
     if (pearls < this.costs.single) {
       alert('Not enough Ninja Pearls!');
@@ -169,7 +169,7 @@ class SummonUIController {
     }
 
     // Deduct cost
-    window.Currency?.set(window.Currency?.keys?.pearls, pearls - this.costs.single);
+    window.Resources?.subtract('ninja_pearls', this.costs.single);
 
     // Perform summon
     const result = window.FibonacciSummonEngine?.performSingleSummon();
@@ -192,7 +192,7 @@ class SummonUIController {
   }
 
   async handleMultiSummon() {
-    const pearls = window.Currency?.get(window.Currency?.keys?.pearls, 0) || 0;
+    const pearls = window.Resources?.get('ninja_pearls') || 0;
 
     if (pearls < this.costs.multi) {
       alert('Not enough Ninja Pearls!');
@@ -200,7 +200,7 @@ class SummonUIController {
     }
 
     // Deduct cost
-    window.Currency?.set(window.Currency?.keys?.pearls, pearls - this.costs.multi);
+    window.Resources?.subtract('ninja_pearls', this.costs.multi);
 
     // Perform multi summon
     const results = window.FibonacciSummonEngine?.performMultiSummon();

--- a/summon.html
+++ b/summon.html
@@ -185,7 +185,7 @@
   </div>
 
   <!-- Scripts -->
-  <script src="js/currency.js"></script>
+  <script src="js/resources.js"></script>
   <script src="js/character_inv.js"></script>
   <script src="js/summon/summon-data.js"></script>
   <script src="js/summon/summon-carousel.js"></script>


### PR DESCRIPTION
**Problem:** Currency was not syncing between pages because they used separate storage systems:
- index.html used resources.js (storage key: blazing_resources_v1)
- summon.html used currency.js (storage key: blazing_currency_v1)

**Solution:**
- Replaced currency.js with resources.js in summon.html
- Updated summon-ui.js to use window.Resources instead of window.Currency
- Changed currency keys from Currency.keys.pearls to 'ninja_pearls'
- Updated summon-dev-panel.js to use Resources system
- Added periodic currency display refresh (2s interval)
- Display ryo (coins) instead of generic coins in summon UI

**Files modified:**
- summon.html: Replaced currency.js with resources.js
- js/summon/summon-ui.js: Use Resources API for get/subtract operations
- js/summon/summon-dev-panel.js: Use Resources API for add/set operations

Now when you spend pearls in summon.html, the currency syncs to index.html!