### PR TITLE
fix: unify inventory system to use Resources storage

### DIFF
--- a/css/inventory.css
+++ b/css/inventory.css
@@ -352,6 +352,22 @@ body {
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
 }
 
+.item-usage-note {
+  margin-top: 15px;
+  padding: 12px;
+  background: rgba(70, 130, 180, 0.2);
+  border: 1px solid rgba(100, 149, 237, 0.4);
+  border-radius: 6px;
+  color: #87ceeb;
+  font-size: 13px;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.item-usage-note.hidden {
+  display: none;
+}
+
 /* Scrollbar Styling */
 .inventory-content::-webkit-scrollbar {
   width: 8px;

--- a/inventory.html
+++ b/inventory.html
@@ -66,6 +66,7 @@
           <span class="quantity-label">Owned:</span>
           <span id="modal-item-quantity" class="quantity-value">0</span>
         </div>
+        <div id="item-usage-note" class="item-usage-note hidden"></div>
       </div>
     </div>
   </div>
@@ -100,6 +101,7 @@
     </div>
   </div>
 
+  <script src="js/resources.js"></script>
   <script src="js/inventory.js"></script>
   <script src="js/navigation.js"></script>
 </body>

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1,64 +1,9 @@
-// js/inventory.js - Item Inventory Management
+// js/inventory.js - Item Inventory Management (Unified with Resources)
 document.addEventListener('DOMContentLoaded', () => {
-  // Initialize inventory from localStorage
-  const INVENTORY_KEY = 'player_inventory';
-
-  // Default item database
-  const ITEMS_DATABASE = {
-    awakening: [
-      { id: 'scroll_3star', name: '3★ Awakening Scroll', icon: 'assets/items/scroll_3star.png', description: 'Used to awaken 3★ characters to 4★.' },
-      { id: 'scroll_4star', name: '4★ Awakening Scroll', icon: 'assets/items/scroll_4star.png', description: 'Used to awaken 4★ characters to 5★.' },
-      { id: 'scroll_5star', name: '5★ Awakening Scroll', icon: 'assets/items/scroll_5star.png', description: 'Used to awaken 5★ characters to 6★.' },
-      { id: 'crystal_fire', name: 'Fire Crystal', icon: 'assets/items/crystal_fire.png', description: 'Fire-attribute awakening material.' },
-      { id: 'crystal_water', name: 'Water Crystal', icon: 'assets/items/crystal_water.png', description: 'Water-attribute awakening material.' },
-      { id: 'crystal_earth', name: 'Earth Crystal', icon: 'assets/items/crystal_earth.png', description: 'Earth-attribute awakening material.' },
-      { id: 'crystal_wind', name: 'Wind Crystal', icon: 'assets/items/crystal_wind.png', description: 'Wind-attribute awakening material.' },
-      { id: 'crystal_lightning', name: 'Lightning Crystal', icon: 'assets/items/crystal_lightning.png', description: 'Lightning-attribute awakening material.' }
-    ],
-    enhancement: [
-      { id: 'pill_hp', name: 'HP Pill', icon: 'assets/items/pill_hp.png', description: 'Increases HP stat permanently.' },
-      { id: 'pill_atk', name: 'ATK Pill', icon: 'assets/items/pill_atk.png', description: 'Increases ATK stat permanently.' },
-      { id: 'pill_def', name: 'DEF Pill', icon: 'assets/items/pill_def.png', description: 'Increases DEF stat permanently.' },
-      { id: 'pill_speed', name: 'Speed Pill', icon: 'assets/items/pill_speed.png', description: 'Increases Speed stat permanently.' }
-    ],
-    ramen: [
-      { id: 'ramen_1star', name: '1★ Ramen', icon: 'assets/items/ramen_1star.png', description: 'Provides 500 EXP. Best for low-level characters.' },
-      { id: 'ramen_2star', name: '2★ Ramen', icon: 'assets/items/ramen_2star.png', description: 'Provides 1,500 EXP. Good for mid-level characters.' },
-      { id: 'ramen_3star', name: '3★ Ramen', icon: 'assets/items/ramen_3star.png', description: 'Provides 5,000 EXP. Great for high-level characters.' },
-      { id: 'ramen_4star', name: '4★ Ramen', icon: 'assets/items/ramen_4star.png', description: 'Provides 15,000 EXP. Excellent for max-level characters.' },
-      { id: 'ramen_5star', name: '5★ Ramen', icon: 'assets/items/ramen_5star.png', description: 'Provides 50,000 EXP. The ultimate experience boost.' }
-    ],
-    scrolls: [
-      { id: 'limit_break_crystal', name: 'Limit Break Crystal', icon: 'assets/items/lb_crystal.png', description: 'Used to perform Limit Break on max-level characters.' },
-      { id: 'acquisition_stone', name: 'Acquisition Stone', icon: 'assets/items/acq_stone.png', description: 'Can be exchanged for specific characters in the shop.' },
-      { id: 'granny_coin', name: 'Granny Cat Coin', icon: 'assets/items/granny_coin.png', description: 'Special currency for Granny Cat Shop.' }
-    ]
-  };
-
-  // Get or initialize inventory
-  function getInventory() {
-    const stored = localStorage.getItem(INVENTORY_KEY);
-    if (stored) {
-      return JSON.parse(stored);
-    }
-    // Initialize with sample items
-    return {
-      'scroll_3star': 5,
-      'scroll_4star': 3,
-      'scroll_5star': 1,
-      'crystal_fire': 10,
-      'crystal_water': 8,
-      'ramen_1star': 25,
-      'ramen_2star': 15,
-      'ramen_3star': 8,
-      'pill_hp': 5,
-      'pill_atk': 3,
-      'limit_break_crystal': 2
-    };
-  }
-
-  function saveInventory(inventory) {
-    localStorage.setItem(INVENTORY_KEY, JSON.stringify(inventory));
+  // Wait for Resources to be available
+  if (typeof window.Resources === 'undefined') {
+    console.error('[Inventory] Resources system not available!');
+    return;
   }
 
   // Render items for a specific category
@@ -66,8 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const grid = document.getElementById(`${category}-grid`);
     if (!grid) return;
 
-    const items = ITEMS_DATABASE[category] || [];
-    const inventory = getInventory();
+    const items = window.Resources.getItemsByCategory(category);
     grid.innerHTML = '';
 
     if (items.length === 0) {
@@ -82,34 +26,67 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     items.forEach(item => {
-      const quantity = inventory[item.id] || 0;
-
       const card = document.createElement('div');
       card.className = 'item-card';
       card.innerHTML = `
         <img src="${item.icon}" alt="${item.name}" class="item-icon" onerror="this.src='assets/items/placeholder.png'">
         <div class="item-name">${item.name}</div>
-        <div class="item-quantity">×${quantity}</div>
+        <div class="item-quantity">×${item.quantity}</div>
       `;
 
-      card.addEventListener('click', () => showItemDetails(item, quantity));
+      card.addEventListener('click', () => showItemDetails(item));
       grid.appendChild(card);
     });
   }
 
   // Show item details modal
-  function showItemDetails(item, quantity) {
+  function showItemDetails(item) {
     const modal = document.getElementById('item-modal');
     const icon = document.getElementById('modal-item-icon');
     const name = document.getElementById('modal-item-name');
     const description = document.getElementById('modal-item-description');
     const quantityDisplay = document.getElementById('modal-item-quantity');
+    const usageNote = document.getElementById('item-usage-note');
 
     icon.src = item.icon;
     icon.onerror = () => { icon.src = 'assets/items/placeholder.png'; };
     name.textContent = item.name;
     description.textContent = item.description;
-    quantityDisplay.textContent = quantity;
+    quantityDisplay.textContent = item.quantity;
+
+    // Show usage note based on item category
+    if (usageNote) {
+      let noteText = '';
+      switch(item.category) {
+        case 'ramen':
+        case 'enhancement':
+          noteText = 'Use this item in the Characters page to enhance your characters.';
+          break;
+        case 'awakening':
+          noteText = 'Use this material in the Awakening system to upgrade character tiers.';
+          break;
+        case 'scrolls':
+          if (item.id === 'limit_break_crystal') {
+            noteText = 'Use this crystal in the Limit Break system to increase character level caps.';
+          } else {
+            noteText = 'Use these materials in various character enhancement systems.';
+          }
+          break;
+        default:
+          noteText = '';
+      }
+
+      if (noteText) {
+        usageNote.textContent = noteText;
+        usageNote.classList.remove('hidden');
+      } else {
+        usageNote.classList.add('hidden');
+      }
+    }
+
+    // Store current item for potential use
+    modal.dataset.itemId = item.id;
+    modal.dataset.itemCategory = item.category;
 
     modal.classList.remove('hidden');
   }
@@ -146,12 +123,10 @@ document.addEventListener('DOMContentLoaded', () => {
   // Initialize with awakening materials tab
   renderItems('awakening');
 
-  // Public API for adding items (can be called from mission completion)
+  // Public API for adding/removing items (wrapper around Resources)
   window.InventoryManager = {
     addItem: function(itemId, quantity = 1) {
-      const inventory = getInventory();
-      inventory[itemId] = (inventory[itemId] || 0) + quantity;
-      saveInventory(inventory);
+      const result = window.Resources.add(itemId, quantity);
 
       // Re-render current tab if on inventory page
       const activeTab = document.querySelector('.tab-btn.active');
@@ -159,19 +134,15 @@ document.addEventListener('DOMContentLoaded', () => {
         renderItems(activeTab.dataset.tab);
       }
 
-      return inventory[itemId];
+      return result;
     },
 
     removeItem: function(itemId, quantity = 1) {
-      const inventory = getInventory();
-      if (!inventory[itemId] || inventory[itemId] < quantity) {
+      if (!window.Resources.has(itemId, quantity)) {
         return false; // Not enough items
       }
-      inventory[itemId] -= quantity;
-      if (inventory[itemId] === 0) {
-        delete inventory[itemId];
-      }
-      saveInventory(inventory);
+
+      window.Resources.subtract(itemId, quantity);
 
       // Re-render current tab if on inventory page
       const activeTab = document.querySelector('.tab-btn.active');
@@ -183,12 +154,30 @@ document.addEventListener('DOMContentLoaded', () => {
     },
 
     getItemQuantity: function(itemId) {
-      const inventory = getInventory();
-      return inventory[itemId] || 0;
+      return window.Resources.get(itemId);
+    },
+
+    hasItem: function(itemId, quantity = 1) {
+      return window.Resources.has(itemId, quantity);
     },
 
     getAllItems: function() {
-      return getInventory();
+      return window.Resources.getAll();
+    },
+
+    // Refresh the current view
+    refresh: function() {
+      const activeTab = document.querySelector('.tab-btn.active');
+      if (activeTab) {
+        renderItems(activeTab.dataset.tab);
+      }
     }
   };
+
+  // Listen for storage events from other tabs/windows
+  window.addEventListener('storage', (e) => {
+    if (e.key === 'blazing_resources_v1') {
+      window.InventoryManager.refresh();
+    }
+  });
 });

--- a/js/resources.js
+++ b/js/resources.js
@@ -10,32 +10,58 @@
   // Material types and their default quantities
   const MATERIAL_TYPES = {
     // Awakening materials (tier-specific)
-    "awakening_stone_3": { name: "3★ Awakening Stone", desc: "Used to awaken 3★ characters" },
-    "awakening_stone_4": { name: "4★ Awakening Stone", desc: "Used to awaken 4★ characters" },
-    "awakening_stone_5": { name: "5★ Awakening Stone", desc: "Used to awaken 5★ characters" },
-    "awakening_stone_6": { name: "6★ Awakening Stone", desc: "Used to awaken 6★ characters" },
-    "awakening_stone_7": { name: "7★ Awakening Stone", desc: "Used to awaken 7★ characters" },
-    "awakening_stone_8": { name: "8★ Awakening Stone", desc: "Used to awaken 8★ characters" },
-    "awakening_stone_9": { name: "9★ Awakening Stone", desc: "Used to awaken 9★ characters" },
+    "awakening_stone_3": { name: "3★ Awakening Stone", desc: "Used to awaken 3★ characters", icon: "assets/items/scroll_3star.png", category: "awakening" },
+    "awakening_stone_4": { name: "4★ Awakening Stone", desc: "Used to awaken 4★ characters", icon: "assets/items/scroll_4star.png", category: "awakening" },
+    "awakening_stone_5": { name: "5★ Awakening Stone", desc: "Used to awaken 5★ characters", icon: "assets/items/scroll_5star.png", category: "awakening" },
+    "awakening_stone_6": { name: "6★ Awakening Stone", desc: "Used to awaken 6★ characters", icon: "assets/items/scroll_6star.png", category: "awakening" },
+    "awakening_stone_7": { name: "7★ Awakening Stone", desc: "Used to awaken 7★ characters", icon: "assets/items/scroll_7star.png", category: "awakening" },
+    "awakening_stone_8": { name: "8★ Awakening Stone", desc: "Used to awaken 8★ characters", icon: "assets/items/scroll_8star.png", category: "awakening" },
+    "awakening_stone_9": { name: "9★ Awakening Stone", desc: "Used to awaken 9★ characters", icon: "assets/items/scroll_9star.png", category: "awakening" },
 
     // Limit break materials
-    "limit_break_crystal": { name: "Limit Break Crystal", desc: "Breaks level limits for max-tier characters" },
-    "dupe_crystal": { name: "Dupe Crystal", desc: "Obtained from duplicate characters" },
+    "limit_break_crystal": { name: "Limit Break Crystal", desc: "Breaks level limits for max-tier characters", icon: "assets/items/lb_crystal.png", category: "scrolls" },
+    "dupe_crystal": { name: "Dupe Crystal", desc: "Obtained from duplicate characters", icon: "assets/items/dupe_crystal.png", category: "scrolls" },
 
     // Element-specific scrolls
-    "scroll_body": { name: "Body Scroll", desc: "Body element awakening material" },
-    "scroll_skill": { name: "Skill Scroll", desc: "Skill element awakening material" },
-    "scroll_bravery": { name: "Bravery Scroll", desc: "Bravery element awakening material" },
-    "scroll_wisdom": { name: "Wisdom Scroll", desc: "Wisdom element awakening material" },
-    "scroll_heart": { name: "Heart Scroll", desc: "Heart element awakening material" },
+    "scroll_body": { name: "Body Scroll", desc: "Body element awakening material", icon: "assets/items/scroll_body.png", category: "scrolls" },
+    "scroll_skill": { name: "Skill Scroll", desc: "Skill element awakening material", icon: "assets/items/scroll_skill.png", category: "scrolls" },
+    "scroll_bravery": { name: "Bravery Scroll", desc: "Bravery element awakening material", icon: "assets/items/scroll_bravery.png", category: "scrolls" },
+    "scroll_wisdom": { name: "Wisdom Scroll", desc: "Wisdom element awakening material", icon: "assets/items/scroll_wisdom.png", category: "scrolls" },
+    "scroll_heart": { name: "Heart Scroll", desc: "Heart element awakening material", icon: "assets/items/scroll_heart.png", category: "scrolls" },
+    "scroll_basic": { name: "Basic Scroll", desc: "Common awakening material", icon: "assets/icons/materials/scroll_basic.png", category: "scrolls" },
+    "scroll_advanced": { name: "Advanced Scroll", desc: "Rare awakening material", icon: "assets/icons/materials/scroll_advanced.png", category: "scrolls" },
 
     // Character-specific materials
-    "character_stone": { name: "Character Stone", desc: "Character-specific awakening material" },
+    "character_stone": { name: "Character Stone", desc: "Character-specific awakening material", icon: "assets/items/character_stone.png", category: "awakening" },
+
+    // Elemental Crystals
+    "crystal_fire": { name: "Fire Crystal", desc: "Fire-attribute awakening material", icon: "assets/items/crystal_fire.png", category: "awakening" },
+    "crystal_water": { name: "Water Crystal", desc: "Water-attribute awakening material", icon: "assets/items/crystal_water.png", category: "awakening" },
+    "crystal_earth": { name: "Earth Crystal", desc: "Earth-attribute awakening material", icon: "assets/items/crystal_earth.png", category: "awakening" },
+    "crystal_wind": { name: "Wind Crystal", desc: "Wind-attribute awakening material", icon: "assets/items/crystal_wind.png", category: "awakening" },
+    "crystal_lightning": { name: "Lightning Crystal", desc: "Lightning-attribute awakening material", icon: "assets/items/crystal_lightning.png", category: "awakening" },
+
+    // Ramen (EXP Items)
+    "ramen_1star": { name: "1★ Ramen", desc: "Provides 500 EXP. Best for low-level characters.", icon: "assets/items/ramen_1star.png", category: "ramen", exp: 500 },
+    "ramen_2star": { name: "2★ Ramen", desc: "Provides 1,500 EXP. Good for mid-level characters.", icon: "assets/items/ramen_2star.png", category: "ramen", exp: 1500 },
+    "ramen_3star": { name: "3★ Ramen", desc: "Provides 5,000 EXP. Great for high-level characters.", icon: "assets/items/ramen_3star.png", category: "ramen", exp: 5000 },
+    "ramen_4star": { name: "4★ Ramen", desc: "Provides 15,000 EXP. Excellent for max-level characters.", icon: "assets/items/ramen_4star.png", category: "ramen", exp: 15000 },
+    "ramen_5star": { name: "5★ Ramen", desc: "Provides 50,000 EXP. The ultimate experience boost.", icon: "assets/items/ramen_5star.png", category: "ramen", exp: 50000 },
+
+    // Pills (Stat Enhancement)
+    "pill_hp": { name: "HP Pill", desc: "Increases HP stat permanently by 100.", icon: "assets/items/pill_hp.png", category: "enhancement", statBoost: { hp: 100 } },
+    "pill_atk": { name: "ATK Pill", desc: "Increases ATK stat permanently by 50.", icon: "assets/items/pill_atk.png", category: "enhancement", statBoost: { atk: 50 } },
+    "pill_def": { name: "DEF Pill", desc: "Increases DEF stat permanently by 50.", icon: "assets/items/pill_def.png", category: "enhancement", statBoost: { def: 50 } },
+    "pill_speed": { name: "Speed Pill", desc: "Increases Speed stat permanently by 25.", icon: "assets/items/pill_speed.png", category: "enhancement", statBoost: { speed: 25 } },
+
+    // Special Items
+    "acquisition_stone": { name: "Acquisition Stone", desc: "Can be exchanged for specific characters in the shop.", icon: "assets/items/acq_stone.png", category: "scrolls" },
+    "granny_coin": { name: "Granny Cat Coin", desc: "Special currency for Granny Cat Shop.", icon: "assets/items/granny_coin.png", category: "scrolls" },
 
     // Currencies
-    "ryo": { name: "Ryo", desc: "Standard currency for various operations" },
-    "ninja_pearls": { name: "Ninja Pearls", desc: "Premium currency for summons and special items" },
-    "shinobites": { name: "Shinobites", desc: "Gacha currency for character summons" }
+    "ryo": { name: "Ryo", desc: "Standard currency for various operations", icon: "assets/items/ryo.png", category: "currency" },
+    "ninja_pearls": { name: "Ninja Pearls", desc: "Premium currency for summons and special items", icon: "assets/items/pearls.png", category: "currency" },
+    "shinobites": { name: "Shinobites", desc: "Gacha currency for character summons", icon: "assets/items/shinobites.png", category: "currency" }
   };
 
   let _resources = {};
@@ -80,6 +106,22 @@
         "scroll_wisdom": 20,
         "scroll_heart": 20,
         "character_stone": 30,
+        "crystal_fire": 10,
+        "crystal_water": 8,
+        "crystal_earth": 8,
+        "crystal_wind": 8,
+        "crystal_lightning": 8,
+        "ramen_1star": 25,
+        "ramen_2star": 15,
+        "ramen_3star": 8,
+        "ramen_4star": 3,
+        "ramen_5star": 1,
+        "pill_hp": 5,
+        "pill_atk": 3,
+        "pill_def": 3,
+        "pill_speed": 3,
+        "acquisition_stone": 2,
+        "granny_coin": 10,
         "ryo": 0,
         "ninja_pearls": 0,
         "shinobites": 0
@@ -167,6 +209,23 @@
     return { ...MATERIAL_TYPES };
   }
 
+  function getItemsByCategory(category) {
+    const items = [];
+    for (const [id, info] of Object.entries(MATERIAL_TYPES)) {
+      if (info.category === category) {
+        items.push({
+          id,
+          name: info.name,
+          icon: info.icon || 'assets/items/placeholder.png',
+          description: info.desc,
+          quantity: get(id),
+          ...info
+        });
+      }
+    }
+    return items;
+  }
+
   // Initialize on load
   load();
 
@@ -182,6 +241,7 @@
     set,
     getMaterialInfo,
     getAllMaterialTypes,
+    getItemsByCategory,
     MATERIAL_TYPES
   };
 

--- a/js/shop.js
+++ b/js/shop.js
@@ -319,27 +319,28 @@
     },
 
     addItemsToInventory(item, quantity) {
-      // Get or create inventory
-      let inventory = JSON.parse(localStorage.getItem('blazing_shop_inventory_v1') || '{}');
+      // Use unified Resources system instead of separate shop inventory
+      if (window.Resources) {
+        // Handle special items that add resources directly (like ryo pouches)
+        if (item.value) {
+          // This is a resource package (e.g., ryo_small gives ryo)
+          for (const [resourceId, amount] of Object.entries(item.value)) {
+            window.Resources.add(resourceId, amount * quantity);
+            console.log(`[Shop] Added ${amount * quantity} ${resourceId} to resources`);
+          }
+        } else {
+          // This is a regular item (ramen, scrolls, etc.)
+          window.Resources.add(item.id, quantity);
+          console.log(`[Shop] Added ${quantity}x ${item.name} to inventory`);
+        }
 
-      // Initialize category if doesn't exist
-      if (!inventory[item.category]) {
-        inventory[item.category] = {};
+        // Refresh inventory UI if it's available
+        if (window.InventoryManager && typeof window.InventoryManager.refresh === 'function') {
+          window.InventoryManager.refresh();
+        }
+      } else {
+        console.error('[Shop] Resources system not available!');
       }
-
-      // Add or increment item count
-      if (!inventory[item.category][item.id]) {
-        inventory[item.category][item.id] = {
-          ...item,
-          count: 0
-        };
-      }
-
-      inventory[item.category][item.id].count += quantity;
-
-      // Save inventory
-      localStorage.setItem('blazing_shop_inventory_v1', JSON.stringify(inventory));
-      console.log(`[Shop] Added ${quantity}x ${item.name} to inventory`);
     },
 
     showSuccessModal(item, quantity) {

--- a/shop.html
+++ b/shop.html
@@ -117,6 +117,7 @@
     </div>
   </div>
 
+  <script src="js/resources.js"></script>
   <script defer src="js/shop.js"></script>
 
   <!-- Navigation Script -->


### PR DESCRIPTION
Fixed critical inventory system issues by unifying three separate storage systems into one:

**Problems Fixed:**
- Eliminated duplicate inventory storage systems (player_inventory, blazing_shop_inventory_v1, blazing_resources_v1)
- Shop purchases now properly add items to the unified inventory
- Mission rewards now integrate with the inventory system
- Standardized item IDs across all systems

**Changes:**
- Updated Resources system to include all item types (ramen, pills, crystals, scrolls)
- Rewrote InventoryManager to read from Resources instead of separate storage
- Updated shop.js to use Resources.add() instead of maintaining separate inventory
- Added item categorization and metadata to Resources
- Added usage notes in inventory UI to guide players
- Added Resources.getItemsByCategory() helper method

**Technical Details:**
- Unified storage key: blazing_resources_v1
- Standardized item IDs: awakening_stone_*, ramen_*, pill_*, crystal_*, scroll_*
- InventoryManager now acts as a wrapper around Resources
- Shop handles both regular items and resource packages (ryo pouches)
- Cross-tab/window storage sync support

**UI Improvements:**
- Items now display properly with correct quantities
- Added helpful usage notes for each item category
- Improved item modal styling
- Real-time inventory refresh when items are added

This fix ensures items purchased from the shop, earned from missions, and used in awakening/limit break systems all work with the same unified inventory.