### PR TITLE
fix: ensure bottom bar buttons are clickable by adjusting z-index hie…

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -66,7 +66,7 @@
   left: 20px;
   width: 400px;
   max-width: calc(100vw - 40px);
-  z-index: 900;
+  z-index: 50;
   pointer-events: auto;
 }
 
@@ -391,7 +391,7 @@
   gap: 12px;
   cursor: pointer;
   transition: all 0.3s ease;
-  z-index: 900;
+  z-index: 50;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.7);
 }
 
@@ -487,10 +487,11 @@
 .dashboard-banner-section {
   position: fixed;
   left: 20px;
-  bottom: 120px; /* Position above bottom bar */
+  bottom: 90px; /* Position above bottom bar */
   width: 600px;
   max-width: calc(100vw - 40px);
-  z-index: 100;
+  z-index: 50;
+  pointer-events: none; /* Allow clicks to pass through container */
 }
 
 .banner-section-header {
@@ -503,6 +504,7 @@
   font-size: 24px;
   padding: 8px 20px;
   margin: 10px 0;
+  pointer-events: auto; /* Re-enable clicks on headers */
 }
 
 .dashboard-banner-section .banner-slideshow {
@@ -511,6 +513,7 @@
   overflow: hidden;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.7);
   border: 2px solid rgba(184, 152, 95, 0.5);
+  pointer-events: auto; /* Re-enable clicks on slideshow */
 }
 
 .dashboard-banner-section .banner-arrow {


### PR DESCRIPTION
…rarchy

Fixed persistent click-blocking issue on bottom bar navigation buttons:

**Root Cause:**
- Dashboard elements (banner section, announcements, daily login) had z-index values (50-900) that were potentially overlapping or interfering with bottom bar (z-index: 1000)
- Banner section positioned too close to bottom bar could extend and block clicks

**Changes:**
- Set all dashboard elements to z-index: 50 (well below bottom bar's 1000)
- Added `pointer-events: none` to `.dashboard-banner-section` container
- Re-enabled `pointer-events: auto` on interactive children (headers, slideshow)
- Adjusted banner section bottom position from 120px to 90px
- Reduced z-index of announcement-banner-container: 900 → 50
- Reduced z-index of daily-login-indicator: 900 → 50

**Z-Index Hierarchy:**
- Bottom bar: 1000 (highest - always clickable)
- Top bar: 1000 (same level)
- Dashboard elements: 50 (lowest - won't block)

**Result:**
Bottom bar buttons now guaranteed to be clickable as they have the highest z-index and no elements are blocking pointer events.