### PR TITLE
refactor: move banners to top-left and reposition calendar/mailbox icons

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -204,12 +204,15 @@
   transform: scale(1.3);
 }
 
-/* === Top Bar Enhancements === */
-.top-bar-icons {
+/* === Dashboard Icons Container (Calendar & Mailbox) === */
+.dashboard-icons-container {
+  position: fixed;
+  top: 80px;
+  right: 180px; /* Next to daily login */
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-right: 20px;
+  z-index: 50;
 }
 
 .icon-button {
@@ -487,7 +490,7 @@
 .dashboard-banner-section {
   position: fixed;
   left: 20px;
-  bottom: 90px; /* Position above bottom bar */
+  top: 140px; /* Under top bar and daily login */
   width: 600px;
   max-width: calc(100vw - 40px);
   z-index: 50;
@@ -561,7 +564,9 @@
     padding: 8px 12px;
   }
 
-  .top-bar-icons {
+  .dashboard-icons-container {
+    top: 70px;
+    right: 140px;
     gap: 8px;
   }
 
@@ -580,7 +585,7 @@
 
   .dashboard-banner-section {
     width: 500px;
-    bottom: 100px;
+    top: 130px;
   }
 
   .dashboard-banner-section .banner-slideshow {
@@ -611,7 +616,9 @@
     right: 10px;
   }
 
-  .top-bar-icons {
+  .dashboard-icons-container {
+    top: 200px;
+    right: 10px;
     gap: 6px;
   }
 
@@ -636,7 +643,7 @@
   .dashboard-banner-section {
     width: calc(100vw - 20px);
     left: 10px;
-    bottom: 80px;
+    top: 260px;
   }
 
   .dashboard-banner-section .banner-slideshow {

--- a/index.html
+++ b/index.html
@@ -43,17 +43,6 @@
       <span class="collection-label">Collection</span>
     </div>
 
-    <div class="top-bar-icons">
-      <button class="icon-button" id="btn-calendar" aria-label="Calendar" title="Daily Streak Calendar">
-        <img src="assets/icons/main/calendar.png" alt="Calendar" onerror="this.style.display='none'; this.parentElement.innerHTML='📅';">
-      </button>
-
-      <button class="icon-button" id="btn-mailbox" aria-label="Mailbox" title="Mailbox">
-        <img src="assets/icons/main/mailbox.png" alt="Mailbox" onerror="this.style.display='none'; this.parentElement.innerHTML='📬';">
-        <div class="icon-badge" id="mailbox-badge" style="display: none;">0</div>
-      </button>
-    </div>
-
     <div class="currency-hud">
       <div class="currency-item ninja-pearls">
         <img src="assets/icons/currency/ninjapearl.png" alt="Ninja Pearls" class="currency-icon"
@@ -80,6 +69,18 @@
       <div class="daily-login-label">Daily Login</div>
       <div class="daily-login-day" id="daily-login-day">Day 1/7</div>
     </div>
+  </div>
+
+  <!-- Calendar and Mailbox Icons (next to Daily Login) -->
+  <div class="dashboard-icons-container">
+    <button class="icon-button" id="btn-calendar" aria-label="Calendar" title="Daily Streak Calendar">
+      <img src="assets/icons/main/calendar.png" alt="Calendar" onerror="this.style.display='none'; this.parentElement.innerHTML='📅';">
+    </button>
+
+    <button class="icon-button" id="btn-mailbox" aria-label="Mailbox" title="Mailbox">
+      <img src="assets/icons/main/mailbox.png" alt="Mailbox" onerror="this.style.display='none'; this.parentElement.innerHTML='📬';">
+      <div class="icon-badge" id="mailbox-badge" style="display: none;">0</div>
+    </button>
   </div>
 
   <!-- Announcement Banner Container -->


### PR DESCRIPTION
Repositioned dashboard elements for improved layout:

**Banner Section Changes:**
- Moved `.dashboard-banner-section` from bottom-left to top-left
- Changed position: `bottom: 90px` → `top: 140px`
- Now appears under top bar and daily login indicator
- "ANNOUNCEMENTS" and "TIME LIMITED BANNER" headers now at top-left

**Calendar & Mailbox Repositioning:**
- Removed calendar/mailbox from top bar
- Created new `.dashboard-icons-container` for calendar and mailbox
- Positioned at `top: 80px, right: 180px` (next to daily login)
- Both icons maintain same styling and functionality

**Layout Structure:**
```
Top Bar (60px)
├─ Ninja Rank + Progress
├─ Collection Stats
└─ Currency HUD

Below Top Bar:
├─ Daily Login (right: 20px)
├─ Calendar/Mailbox Icons (right: 180px, next to daily login)
└─ Banner Section (left: 20px, top: 140px)
    ├─ ANNOUNCEMENTS header
    ├─ TIME LIMITED BANNER header
    └─ Banner slideshow
```

**Responsive Updates:**
- Tablet (768px): Banner at `top: 130px`, icons at `right: 140px`
- Mobile (480px): Banner at `top: 260px`, icons at `top: 200px`

All elements maintain dark blue/gold aesthetic with proper z-index hierarchy.