### PR TITLE
refactor: reduce banner slideshow font sizes and navigation dots

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -538,11 +538,27 @@
 }
 
 .dashboard-banner-section .banner-info-title {
-  font-size: 24px;
+  font-size: 16px; /* Reduced from 24px */
 }
 
 .dashboard-banner-section .banner-info-subtitle {
-  font-size: 14px;
+  font-size: 11px; /* Reduced from 14px */
+}
+
+/* Make navigation dots smaller for dashboard */
+.dashboard-banner-section .banner-nav-dots {
+  gap: 6px; /* Reduced from 10px */
+  bottom: 10px; /* Adjusted position */
+}
+
+.dashboard-banner-section .banner-dot {
+  width: 8px; /* Reduced from 12px */
+  height: 8px; /* Reduced from 12px */
+  border: 1px solid rgba(255, 255, 255, 0.5); /* Thinner border */
+}
+
+.dashboard-banner-section .banner-dot.active {
+  transform: scale(1.2); /* Reduced from 1.3 */
 }
 
 /* === Responsive Design === */
@@ -593,7 +609,7 @@
   }
 
   .dashboard-banner-section .banner-info-title {
-    font-size: 20px;
+    font-size: 14px; /* Reduced from 20px */
   }
 }
 
@@ -651,11 +667,11 @@
   }
 
   .dashboard-banner-section .banner-info-title {
-    font-size: 16px;
+    font-size: 12px; /* Reduced from 16px */
   }
 
   .dashboard-banner-section .banner-info-subtitle {
-    font-size: 12px;
+    font-size: 10px; /* Reduced from 12px */
   }
 
   .dashboard-banner-section .banner-arrow {


### PR DESCRIPTION
- Reduce banner title font: 24px → 16px (desktop)
- Reduce banner subtitle font: 14px → 11px (desktop)
- Make navigation dots smaller: 12px → 8px
- Reduce dot gap: 10px → 6px
- Reduce active dot scale: 1.3 → 1.2
- Update responsive breakpoints accordingly for tablet/mobile