### PR TITLE
fix: implement bench unit chakra holder frames properly

### DIFF
--- a/css/battle-chakra-wheel.css
+++ b/css/battle-chakra-wheel.css
@@ -102,7 +102,6 @@
   width: 150px !important;
   height: 150px !important;
   object-fit: fill !important;
-  content: url("../assets/ui/frames/chakraholder_iconbench.png");
 }
 
 /* =========================================

--- a/js/battle/battle-chakra-wheel.js
+++ b/js/battle/battle-chakra-wheel.js
@@ -71,10 +71,13 @@
       chakraSegment.alt = 'Chakra gauge';
       chakraContainer.appendChild(chakraSegment);
 
-      // Create chakra frame overlay (top layer, 140×140px, z-index: 10)
+      // Create chakra frame overlay (top layer, 140×140px for active, 60×60px for bench, z-index: 10)
       const chakraFrame = document.createElement('img');
       chakraFrame.className = 'chakra-frame';
-      chakraFrame.src = 'assets/ui/frames/chakraholder_icon.png';
+      // Use different frame asset for bench units
+      chakraFrame.src = isBench ?
+        'assets/ui/frames/chakraholder_iconbench.png' :
+        'assets/ui/frames/chakraholder_icon.png';
       chakraFrame.alt = 'Chakra frame';
 
       // Assemble structure: portrait → chakra container → frame
@@ -93,11 +96,19 @@
       // Cache the wheel element
       this.wheelCache.set(unit.id, unitRing);
 
+      // For active units, preserve any bench portraits that may be nested
+      const existingBenchPortrait = portraitContainer.querySelector('.bench-portrait-container');
+
       // Replace portrait container content
       portraitContainer.innerHTML = '';
       portraitContainer.appendChild(unitRing);
 
-      console.log(`[ChakraWheel] Chakra accumulation system created for ${unit.name}`);
+      // Re-append bench portrait if it existed (for active units with bench)
+      if (existingBenchPortrait && !isBench) {
+        portraitContainer.appendChild(existingBenchPortrait);
+      }
+
+      console.log(`[ChakraWheel] Chakra accumulation system created for ${unit.name}${isBench ? ' (bench)' : ''}`);
 
       return unitRing;
     },


### PR DESCRIPTION
The bench portraits weren't showing because of two JavaScript issues:

1. Chakra frame asset selection:
   - createChakraWheel() was ignoring the isBench parameter
   - All units (active and bench) used same frame: chakraholder_icon.png
   - Now properly uses chakraholder_iconbench.png for bench units

2. Bench portrait preservation:
   - When creating active unit chakra wheels, innerHTML was cleared
   - This removed the nested bench portrait containers before their wheels were created
   - Now saves bench container reference before clearing and re-appends it
   - This preserves the bench container so it can receive its chakra wheel later

CSS Changes:
   - Removed incorrect 'content' property override (doesn't work for img src)
   - Frame asset now properly set via JavaScript src attribute

The bench should now be visible with the correct smaller chakra holder frames positioned at the lower-left of each active unit card.