### PR TITLE
fix: correct summon data file path from summons.json to summon.json

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -178,7 +178,7 @@
 
     try {
       // Load summon banners data
-      const response = await fetch('data/summons.json');
+      const response = await fetch('data/summon.json'); // Fixed: was summons.json
       const summonsData = await response.json();
 
       // Clear carousel


### PR DESCRIPTION
The summon banner carousel was not loading because the JavaScript was trying to fetch 'data/summons.json' (with an 's') but the actual file is 'data/summon.json' (without the 's').

This fixes the missing summon banner carousel on the dashboard.