### PR TITLE
fix: change banner panel from vertical stack to 2-column grid layout

### DIFF
--- a/css/ui-layout.css
+++ b/css/ui-layout.css
@@ -12,14 +12,15 @@
   top: 50%;
   transform: translateY(-50%);
   z-index: 50;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr 1fr; /* Two equal columns */
   gap: 14px;
   pointer-events: auto;
+  width: 600px; /* Total width for 2 columns + gap */
 }
 
 .banner-button {
-  width: 420px;
+  width: 100%; /* Fill grid cell */
   height: 150px;
   background-size: cover;
   background-position: center;
@@ -33,9 +34,10 @@
   overflow: hidden;
 }
 
-/* Missions banner is taller (primary action) */
+/* Missions banner spans both columns (full width) */
 .banner-button.missions {
-  height: 200px;
+  grid-column: 1 / -1; /* Span both columns */
+  height: 150px; /* Same height as others */
 }
 
 /* Hover effect */


### PR DESCRIPTION
- Change .right-banner-panel from flex column to CSS Grid
- Use grid-template-columns: 1fr 1fr for two equal columns
- Make Missions button span both columns with grid-column: 1 / -1
- Set all buttons to same height (150px)
- Change button width from fixed 420px to 100% (fill grid cell)
- Set container width to 600px for 2 columns + gap

This creates the layout:
Row 1: MISSIONS (full-width)
Row 2: CHARACTERS | SUMMON
Row 3: FUSION | SHOP