### PR TITLE
fix: move banner panel left and increase gaps between buttons

### DIFF
--- a/css/ui-layout.css
+++ b/css/ui-layout.css
@@ -15,10 +15,10 @@
   display: grid;
   grid-template-columns: 1fr 1fr; /* Two equal columns */
   grid-auto-rows: 68px; /* Reduced 55%: 150px × 0.45 = 68px */
-  gap: 8px; /* Reduced 55%: 16px × 0.45 = 8px */
+  gap: 12px; /* Increased gap for better spacing between buttons */
   pointer-events: auto;
   width: 216px; /* Reduced 55%: 480px × 0.45 = 216px */
-  margin-right: 24px; /* Space between banner and screen edge */
+  margin-right: 50px; /* Moved left by ~26px (was 24px) */
 }
 
 .banner-button {


### PR DESCRIPTION
Position Adjustments:
- Increase margin-right: 24px → 50px (moves panel ~26px to the left)
- Increase gap between buttons: 8px → 12px (better spacing)

This provides more comfortable spacing between all banner buttons and moves the entire panel away from the right screen edge.