### PR TITLE
fix: eliminate banner button overlaps with proper grid positioning

### DIFF
--- a/css/ui-layout.css
+++ b/css/ui-layout.css
@@ -14,49 +14,54 @@
   z-index: 50;
   display: grid;
   grid-template-columns: 1fr 1fr; /* Two equal columns */
-  grid-auto-rows: 68px; /* Reduced 55%: 150px × 0.45 = 68px */
-  gap: 12px; /* Increased gap for better spacing between buttons */
+  grid-auto-rows: 68px; /* Row height for standard buttons */
+  gap: 12px; /* 12px spacing between all buttons */
   pointer-events: auto;
-  width: 216px; /* Reduced 55%: 480px × 0.45 = 216px */
-  margin-right: 50px; /* Moved left by ~26px (was 24px) */
+  width: 216px; /* Total panel width */
+  margin-right: 50px; /* Space from screen edge */
 }
 
 .banner-button {
+  box-sizing: border-box; /* Include border in dimensions */
   width: 100%; /* Fill grid cell */
   height: 100%; /* Fill row height */
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  border-radius: 4px; /* Reduced 55%: 8px × 0.45 = 4px */
+  border-radius: 4px;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.6); /* Reduced 55%: 4px → 2px, 14px → 6px */
-  border: 1px solid rgba(255, 165, 0, 0.3); /* Reduced 55%: 2px × 0.45 = 1px */
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(255, 165, 0, 0.3);
   position: relative;
   overflow: hidden;
 }
 
 /* Missions banner spans both columns (full width) */
 .banner-button.missions {
-  grid-column: 1 / 3; /* Span both columns */
-  height: 81px; /* Reduced 55%: 180px × 0.45 = 81px */
+  grid-column: 1 / 3; /* Span both columns (full 216px width with 12px gap) */
+  height: 68px; /* Same height as other buttons for consistency */
 }
 
 /* Explicit grid positioning for 2×2 layout below Missions */
 .banner-button.characters {
-  grid-column: 1;
+  grid-column: 1; /* Left column */
+  grid-row: 2; /* Second row */
 }
 
 .banner-button.summon {
-  grid-column: 2;
+  grid-column: 2; /* Right column */
+  grid-row: 2; /* Second row */
 }
 
 .banner-button.fusion {
-  grid-column: 1;
+  grid-column: 1; /* Left column */
+  grid-row: 3; /* Third row */
 }
 
 .banner-button.shop {
-  grid-column: 2;
+  grid-column: 2; /* Right column */
+  grid-row: 3; /* Third row */
 }
 
 /* Hover effect */
@@ -109,21 +114,14 @@
 /* Banner text overlay (temporary until PNGs have text) */
 .banner-button-text {
   position: absolute;
-  bottom: 7px; /* Reduced 55%: 15px × 0.45 = 7px */
-  left: 9px; /* Reduced 55%: 20px × 0.45 = 9px */
-  font-size: 11px; /* Reduced 55%: 24px × 0.45 = 11px */
+  bottom: 7px;
+  left: 9px;
+  font-size: 11px;
   font-weight: 700;
   color: #fff;
   text-shadow: 0 1px 4px rgba(0, 0, 0, 0.9);
-  letter-spacing: 0.4px; /* Reduced 55%: 0.8px × 0.45 = 0.4px */
+  letter-spacing: 0.4px;
   font-family: "Cinzel", serif;
-}
-
-/* Missions button text (larger since button is 81px tall) */
-.banner-button.missions .banner-button-text {
-  font-size: 13px; /* Reduced 55%: 28px × 0.45 = 13px */
-  bottom: 9px; /* Reduced 55%: 20px × 0.45 = 9px */
-  left: 11px; /* Reduced 55%: 24px × 0.45 = 11px */
 }
 
 /* ==========================================


### PR DESCRIPTION
Fixed overlapping issues:
- Added box-sizing: border-box to prevent borders from adding to dimensions
- Made all buttons uniform height (68px) including Missions
- Added explicit grid-row positioning for all buttons:
  * Missions: row 1, columns 1-3 (spans both)
  * Characters: row 2, column 1
  * Summon: row 2, column 2
  * Fusion: row 3, column 1
  * Shop: row 3, column 2
- Removed separate Missions text styling (now consistent with other buttons)

Grid Layout:
- Total width: 216px
- Each column: (216px - 12px gap) / 2 = 102px
- Row height: 68px for all buttons
- Gap: 12px between all buttons (horizontal and vertical)

This ensures:
✓ 12px spacing between ALL boxes
✓ No overlaps
✓ No overflow off screen
✓ Clean 2-column grid structure