### PR TITLE
feat: implement equipped ultimate system with battle integration

### DIFF
--- a/battle.html
+++ b/battle.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="css/battle-team-holder.css" />
   <link rel="stylesheet" href="css/battle-chakra-wheel.css" />
   <link rel="stylesheet" href="css/battle-attack-names.css" />
+  <link rel="stylesheet" href="css/battle-equipped-ultimate.css" />
   <style>
     /* CRITICAL: Force unit sizing to prevent oversized units */
     .battle-unit {
@@ -121,6 +122,15 @@
         <button id="btn-speed">×1</button>
       </div>
     </div>
+
+    <!-- Equipped Ultimate Button (Once-Per-Battle) -->
+    <div class="equipped-ultimate-container">
+      <button id="equipped-ultimate-btn" class="equipped-ultimate-btn" disabled>
+        <span class="equipped-ultimate-icon">⚡</span>
+        <span>Equipped Ultimate</span>
+      </button>
+      <div class="equipped-ultimate-progress" id="equipped-ultimate-progress">0 / 3 Basic Attacks</div>
+    </div>
   </main>
   <div id="battle-result" class="hidden">
     <div class="result-container">
@@ -130,6 +140,7 @@
   </div>
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js" onerror="this.onerror=null;this.src='js/lib/anime.min.js';"></script>
   <script defer src="js/character_inv.js"></script>
+  <script defer src="js/character-equip.js"></script>
   <script defer src="js/progression.js"></script>
   <script defer src="js/status_effects.js"></script>
   <script defer src="js/status_ui.js"></script>
@@ -155,6 +166,7 @@
   <script defer src="js/battle/battle-missions.js"></script>
   <script defer src="js/battle/battle-narrator.js"></script>
   <script defer src="js/battle/battle-hp-fix.js"></script>
+  <script defer src="js/battle/battle-equipped-ultimate.js"></script>
   <script defer src="js/battle.js"></script>
 </body>
 </html>

--- a/css/battle-equipped-ultimate.css
+++ b/css/battle-equipped-ultimate.css
@@ -1,0 +1,255 @@
+/* ==========================================
+   Battle Equipped Ultimate System
+   ========================================== */
+
+/* Ultimate Ready Indicator on Unit */
+.ultimate-ready-indicator {
+  position: absolute;
+  top: -30px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: linear-gradient(135deg, #ffd700, #ff8c00);
+  color: #1a1410;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 4px 12px;
+  border-radius: 12px;
+  white-space: nowrap;
+  z-index: 100;
+  animation: ultimateReadyPulse 1s ease-in-out infinite, ultimateReadyFloat 2s ease-in-out infinite;
+  box-shadow: 0 4px 12px rgba(255, 215, 0, 0.6);
+}
+
+@keyframes ultimateReadyPulse {
+  0%, 100% {
+    box-shadow: 0 4px 12px rgba(255, 215, 0, 0.6);
+  }
+  50% {
+    box-shadow: 0 6px 20px rgba(255, 215, 0, 0.9);
+  }
+}
+
+@keyframes ultimateReadyFloat {
+  0%, 100% {
+    transform: translateX(-50%) translateY(0);
+  }
+  50% {
+    transform: translateX(-50%) translateY(-5px);
+  }
+}
+
+/* Ultimate Ready Glow on Unit */
+.unit.ultimate-ready {
+  box-shadow: 0 0 20px rgba(255, 215, 0, 0.8);
+  animation: ultimateGlow 1.5s ease-in-out infinite;
+}
+
+@keyframes ultimateGlow {
+  0%, 100% {
+    box-shadow: 0 0 15px rgba(255, 215, 0, 0.6);
+  }
+  50% {
+    box-shadow: 0 0 30px rgba(255, 215, 0, 1);
+  }
+}
+
+/* Equipped Ultimate Button (in battle UI) */
+.equipped-ultimate-container {
+  position: fixed;
+  bottom: 120px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 150;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.equipped-ultimate-btn {
+  background: linear-gradient(135deg, rgba(100, 100, 120, 0.9), rgba(80, 80, 100, 0.9));
+  border: 3px solid rgba(139, 115, 85, 0.6);
+  color: #8b7355;
+  font-size: 16px;
+  font-weight: 700;
+  padding: 16px 32px;
+  border-radius: 12px;
+  cursor: not-allowed;
+  transition: all 0.3s ease;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  opacity: 0.5;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.equipped-ultimate-btn.ready {
+  background: linear-gradient(135deg, #ffd700, #ff8c00);
+  border-color: #ffd700;
+  color: #1a1410;
+  cursor: pointer;
+  opacity: 1;
+  animation: ultimateBtnPulse 2s ease-in-out infinite;
+  box-shadow: 0 6px 20px rgba(255, 215, 0, 0.8);
+}
+
+.equipped-ultimate-btn.ready:hover {
+  transform: scale(1.05) translateY(-2px);
+  box-shadow: 0 8px 25px rgba(255, 215, 0, 1);
+}
+
+.equipped-ultimate-btn.ready:active {
+  transform: scale(0.98);
+}
+
+.equipped-ultimate-btn.used {
+  background: rgba(50, 50, 60, 0.6);
+  border-color: rgba(100, 100, 110, 0.4);
+  color: #666;
+  cursor: not-allowed;
+  opacity: 0.3;
+}
+
+@keyframes ultimateBtnPulse {
+  0%, 100% {
+    box-shadow: 0 6px 20px rgba(255, 215, 0, 0.6);
+  }
+  50% {
+    box-shadow: 0 8px 30px rgba(255, 215, 0, 1);
+  }
+}
+
+.equipped-ultimate-icon {
+  font-size: 24px;
+}
+
+.equipped-ultimate-progress {
+  font-size: 12px;
+  color: #b8985f;
+  text-align: center;
+  font-weight: 600;
+}
+
+.equipped-ultimate-progress.ready {
+  color: #ffd700;
+  animation: progressPulse 1s ease-in-out infinite;
+}
+
+@keyframes progressPulse {
+  0%, 100% {
+    opacity: 0.8;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+/* Ultimate Notification */
+.equipped-ultimate-notification {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  z-index: 200;
+  background: linear-gradient(135deg, rgba(10, 10, 15, 0.98), rgba(30, 30, 40, 0.98));
+  border: 3px solid #ffd700;
+  border-radius: 16px;
+  padding: 30px;
+  min-width: 400px;
+  max-width: 600px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.8), 0 0 30px rgba(255, 215, 0, 0.5);
+  opacity: 0;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.equipped-ultimate-notification.show {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+}
+
+.ultimate-notification-icon {
+  font-size: 64px;
+  flex-shrink: 0;
+}
+
+.ultimate-notification-text {
+  flex: 1;
+}
+
+.ultimate-notification-title {
+  font-size: 24px;
+  font-weight: 700;
+  color: #ffd700;
+  margin-bottom: 10px;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.9);
+}
+
+.ultimate-notification-desc {
+  font-size: 14px;
+  color: #c4b59f;
+  line-height: 1.6;
+}
+
+/* Basic Attack Counter (debug/info display) */
+.basic-attack-counter {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background: rgba(10, 10, 15, 0.9);
+  border: 2px solid rgba(255, 215, 0, 0.6);
+  border-radius: 8px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  color: #ffd700;
+  z-index: 50;
+}
+
+.basic-attack-counter.ready {
+  background: rgba(255, 215, 0, 0.3);
+  border-color: #ffd700;
+  animation: counterReady 1s ease-in-out infinite;
+}
+
+@keyframes counterReady {
+  0%, 100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .equipped-ultimate-container {
+    bottom: 100px;
+  }
+
+  .equipped-ultimate-btn {
+    padding: 12px 24px;
+    font-size: 14px;
+  }
+
+  .equipped-ultimate-notification {
+    min-width: 90%;
+    padding: 20px;
+  }
+
+  .ultimate-notification-icon {
+    font-size: 48px;
+  }
+
+  .ultimate-notification-title {
+    font-size: 20px;
+  }
+
+  .ultimate-notification-desc {
+    font-size: 13px;
+  }
+}

--- a/data/equip-ultimates.json
+++ b/data/equip-ultimates.json
@@ -1,0 +1,203 @@
+{
+  "version": "1.0",
+  "description": "Equippable once-per-battle ultimate abilities that unlock after 3 consecutive basic attacks",
+  "ultimates": [
+    {
+      "id": "rasengan_ultimate",
+      "name": "Massive Rasengan",
+      "description": "Unleash a massive chakra sphere that deals 500% ATK damage to all enemies and ignores 50% of their defense.",
+      "icon": "💥",
+      "chakraCost": 10,
+      "power": 500,
+      "target": "all_enemies",
+      "effects": [
+        {
+          "type": "damage",
+          "multiplier": 5.0,
+          "ignoreDefense": 0.5
+        },
+        {
+          "type": "stun",
+          "chance": 0.2,
+          "duration": 1
+        }
+      ],
+      "animation": "rasengan_blast",
+      "unlock_requirement": 3
+    },
+    {
+      "id": "chidori_ultimate",
+      "name": "Lightning Blade",
+      "description": "Channel lightning through your hand for a devastating strike dealing 600% ATK damage with guaranteed critical hit.",
+      "icon": "⚡",
+      "chakraCost": 10,
+      "power": 600,
+      "target": "single_enemy",
+      "effects": [
+        {
+          "type": "damage",
+          "multiplier": 6.0,
+          "guaranteedCrit": true
+        },
+        {
+          "type": "pierce",
+          "value": true
+        }
+      ],
+      "animation": "chidori_strike",
+      "unlock_requirement": 3
+    },
+    {
+      "id": "sharingan_ultimate",
+      "name": "Mangekyō Sharingan",
+      "description": "Activate Mangekyō Sharingan to buff all allies with +100% ATK and +50% Speed for 3 turns.",
+      "icon": "👁️",
+      "chakraCost": 12,
+      "power": 0,
+      "target": "all_allies",
+      "effects": [
+        {
+          "type": "buff",
+          "stat": "atk",
+          "multiplier": 2.0,
+          "duration": 3
+        },
+        {
+          "type": "buff",
+          "stat": "speed",
+          "multiplier": 1.5,
+          "duration": 3
+        }
+      ],
+      "animation": "sharingan_activation",
+      "unlock_requirement": 3
+    },
+    {
+      "id": "sage_mode_ultimate",
+      "name": "Sage Mode Activation",
+      "description": "Enter Sage Mode, healing all allies for 30% HP and granting immunity to debuffs for 2 turns.",
+      "icon": "🟠",
+      "chakraCost": 15,
+      "power": 0,
+      "target": "all_allies",
+      "effects": [
+        {
+          "type": "heal",
+          "percent": 0.3
+        },
+        {
+          "type": "debuff_immunity",
+          "duration": 2
+        }
+      ],
+      "animation": "sage_mode_aura",
+      "unlock_requirement": 3
+    },
+    {
+      "id": "shadow_clone_ultimate",
+      "name": "Multi Shadow Clone Jutsu",
+      "description": "Create shadow clones to attack all enemies 5 times dealing 200% ATK damage each hit.",
+      "icon": "👥",
+      "chakraCost": 12,
+      "power": 200,
+      "target": "all_enemies",
+      "effects": [
+        {
+          "type": "multi_hit",
+          "hits": 5,
+          "multiplier": 2.0
+        },
+        {
+          "type": "debuff",
+          "status": "confusion",
+          "chance": 0.3,
+          "duration": 2
+        }
+      ],
+      "animation": "shadow_clone_barrage",
+      "unlock_requirement": 3
+    },
+    {
+      "id": "fire_style_ultimate",
+      "name": "Great Fire Annihilation",
+      "description": "Unleash massive flames dealing 450% ATK damage to all enemies and inflicting burn for 3 turns.",
+      "icon": "🔥",
+      "chakraCost": 11,
+      "power": 450,
+      "target": "all_enemies",
+      "effects": [
+        {
+          "type": "damage",
+          "multiplier": 4.5
+        },
+        {
+          "type": "debuff",
+          "status": "burn",
+          "duration": 3,
+          "damagePerTurn": 50
+        },
+        {
+          "type": "debuff",
+          "stat": "def",
+          "multiplier": 0.7,
+          "duration": 3
+        }
+      ],
+      "animation": "fire_annihilation",
+      "unlock_requirement": 3
+    },
+    {
+      "id": "byakugan_ultimate",
+      "name": "Eight Trigrams Sixty-Four Palms",
+      "description": "Precise chakra point strikes dealing 550% ATK damage and sealing the target's ninjutsu for 2 turns.",
+      "icon": "👁️‍🗨️",
+      "chakraCost": 13,
+      "power": 550,
+      "target": "single_enemy",
+      "effects": [
+        {
+          "type": "damage",
+          "multiplier": 5.5
+        },
+        {
+          "type": "seal",
+          "ability": "ninjutsu",
+          "duration": 2
+        },
+        {
+          "type": "chakra_drain",
+          "percent": 0.5
+        }
+      ],
+      "animation": "sixty_four_palms",
+      "unlock_requirement": 3
+    },
+    {
+      "id": "healing_ultimate",
+      "name": "Mystical Palm Technique",
+      "description": "Advanced medical ninjutsu that heals all allies for 50% HP and removes all debuffs.",
+      "icon": "💚",
+      "chakraCost": 14,
+      "power": 0,
+      "target": "all_allies",
+      "effects": [
+        {
+          "type": "heal",
+          "percent": 0.5
+        },
+        {
+          "type": "cleanse",
+          "removeAll": true
+        },
+        {
+          "type": "buff",
+          "status": "regen",
+          "duration": 3,
+          "healPerTurn": 30
+        }
+      ],
+      "animation": "mystical_palm",
+      "unlock_requirement": 3
+    }
+  ]
+}

--- a/js/battle.js
+++ b/js/battle.js
@@ -19,7 +19,9 @@
       'BattleTeamHolder',
       'BattleChakraWheel',
       'BattleInputManager',
-      'BattleAttackNames'
+      'BattleAttackNames',
+      'BattleEquippedUltimate',
+      'CharacterEquip'
     ];
 
     const allLoaded = requiredModules.every(mod => window[mod]);
@@ -66,6 +68,20 @@
         if (this.teamHolder) {
           this.teamHolder.init(this);
           this.teamHolder.renderTeamHolder(this);
+        }
+
+        // Initialize equipped ultimate system
+        if (window.BattleEquippedUltimate) {
+          window.BattleEquippedUltimate.init(this);
+
+          // Register all player units
+          if (this.activeTeam) {
+            this.activeTeam.forEach(unit => {
+              window.BattleEquippedUltimate.registerUnit(unit);
+            });
+          }
+
+          console.log("[Battle] ✅ Equipped ultimate system initialized");
         }
 
         console.log("[Battle] ✅ Battle system ready with all modules");

--- a/js/battle/battle-combat.js
+++ b/js/battle/battle-combat.js
@@ -280,6 +280,11 @@
         attacker.chakra = Math.min(attacker.maxChakra, attacker.chakra + 1);
       }
 
+      // Track basic attack for equipped ultimate system
+      if (window.BattleEquippedUltimate) {
+        window.BattleEquippedUltimate.onBasicAttack(attacker.id);
+      }
+
       // Show damage animation with breakdown
       if (window.BattleAnimations) {
         window.BattleAnimations.showDamage(target, damage, isCritical, core.dom, false, breakdown);
@@ -338,6 +343,11 @@
       } else {
         if (attacker.chakra < cost) return false;
         attacker.chakra -= cost;
+      }
+
+      // Reset basic attack count when using ninjutsu
+      if (window.BattleEquippedUltimate) {
+        window.BattleEquippedUltimate.onNinjutsuUse(attacker.id);
       }
 
       // Get multiplier from skill data
@@ -560,6 +570,11 @@
         attacker.chakra = Math.min(attacker.maxChakra, attacker.chakra + 1);
       }
 
+      // Track basic attack for equipped ultimate system
+      if (window.BattleEquippedUltimate) {
+        window.BattleEquippedUltimate.onBasicAttack(attacker.id);
+      }
+
       if (core.units) {
         core.units.updateUnitDisplay(attacker, core);
       } else {
@@ -665,6 +680,11 @@
       } else {
         if (attacker.chakra < cost) return false;
         attacker.chakra -= cost;
+      }
+
+      // Reset basic attack count when using ninjutsu
+      if (window.BattleEquippedUltimate) {
+        window.BattleEquippedUltimate.onNinjutsuUse(attacker.id);
       }
 
       // Get multiplier

--- a/js/battle/battle-equipped-ultimate.js
+++ b/js/battle/battle-equipped-ultimate.js
@@ -1,0 +1,502 @@
+// js/battle/battle-equipped-ultimate.js
+// Handles equipped ultimate system in battle
+// Tracks basic attack count and enables once-per-battle ultimates
+
+(() => {
+  "use strict";
+
+  const BattleEquippedUltimate = {
+    // State tracking
+    basicAttackCounts: {}, // { unitId: consecutiveBasicAttacks }
+    ultimatesUsed: {},     // { unitId: boolean }
+    ultimateReady: {},     // { unitId: boolean }
+
+    REQUIRED_BASIC_ATTACKS: 3,
+
+    /**
+     * Initialize equipped ultimate system for battle
+     */
+    init(core) {
+      console.log("[BattleEquippedUltimate] Initializing equipped ultimate system");
+      this.basicAttackCounts = {};
+      this.ultimatesUsed = {};
+      this.ultimateReady = {};
+      this.core = core;
+
+      // Setup button click handler
+      this.setupButtonHandler();
+    },
+
+    /**
+     * Setup equipped ultimate button click handler
+     */
+    setupButtonHandler() {
+      const button = document.getElementById('equipped-ultimate-btn');
+      if (button) {
+        button.addEventListener('click', () => this.handleButtonClick());
+        console.log("[BattleEquippedUltimate] Button handler registered");
+      }
+    },
+
+    /**
+     * Handle equipped ultimate button click
+     */
+    async handleButtonClick() {
+      // Find the current active player unit with equipped ultimate ready
+      if (!this.core || !this.core.activeTeam) return;
+
+      const readyUnit = this.core.activeTeam.find(unit =>
+        this.canUseUltimate(unit.id) && this.getEquippedUltimateData(unit)
+      );
+
+      if (!readyUnit) {
+        console.warn("[BattleEquippedUltimate] No ready unit found");
+        return;
+      }
+
+      const ultimate = this.getEquippedUltimateData(readyUnit);
+      if (!ultimate) {
+        console.warn("[BattleEquippedUltimate] No equipped ultimate found");
+        return;
+      }
+
+      // Determine targets based on ultimate target type
+      let targets = [];
+      if (ultimate.target === 'all_enemies') {
+        targets = this.core.enemyTeam.filter(u => u.stats.hp > 0);
+      } else if (ultimate.target === 'single_enemy') {
+        targets = [this.core.enemyTeam.find(u => u.stats.hp > 0)];
+      } else if (ultimate.target === 'all_allies') {
+        targets = this.core.activeTeam.filter(u => u.stats.hp > 0);
+      }
+
+      // Use the equipped ultimate
+      await this.useUltimate(readyUnit.id, ultimate, targets);
+
+      // Update button state
+      this.updateButtonUI();
+    },
+
+    /**
+     * Register a unit for equipped ultimate tracking
+     * @param {Object} unit - Battle unit object
+     */
+    registerUnit(unit) {
+      if (!unit || !unit.id) return;
+
+      this.basicAttackCounts[unit.id] = 0;
+      this.ultimatesUsed[unit.id] = false;
+      this.ultimateReady[unit.id] = false;
+
+      console.log(`[BattleEquippedUltimate] Registered unit: ${unit.id}`);
+    },
+
+    /**
+     * Track when a unit performs a basic attack
+     * @param {string} unitId - Unit identifier
+     */
+    onBasicAttack(unitId) {
+      if (!this.basicAttackCounts.hasOwnProperty(unitId)) {
+        this.basicAttackCounts[unitId] = 0;
+      }
+
+      this.basicAttackCounts[unitId]++;
+
+      console.log(`[BattleEquippedUltimate] ${unitId} basic attack count: ${this.basicAttackCounts[unitId]}`);
+
+      // Update progress UI
+      this.updateProgressUI(unitId);
+
+      // Check if ultimate is now ready
+      if (this.basicAttackCounts[unitId] >= this.REQUIRED_BASIC_ATTACKS && !this.ultimatesUsed[unitId]) {
+        this.ultimateReady[unitId] = true;
+        this.notifyUltimateReady(unitId);
+      }
+    },
+
+    /**
+     * Update progress UI text
+     */
+    updateProgressUI(unitId) {
+      const progressEl = document.getElementById('equipped-ultimate-progress');
+      if (!progressEl) return;
+
+      const count = this.basicAttackCounts[unitId] || 0;
+      const max = this.REQUIRED_BASIC_ATTACKS;
+
+      progressEl.textContent = `${Math.min(count, max)} / ${max} Basic Attacks`;
+
+      if (count >= max && !this.ultimatesUsed[unitId]) {
+        progressEl.classList.add('ready');
+      } else {
+        progressEl.classList.remove('ready');
+      }
+    },
+
+    /**
+     * Update button UI state
+     */
+    updateButtonUI() {
+      const button = document.getElementById('equipped-ultimate-btn');
+      if (!button) return;
+
+      // Check if any unit is ready
+      const anyReady = Object.keys(this.ultimateReady).some(id =>
+        this.ultimateReady[id] && !this.ultimatesUsed[id]
+      );
+
+      const anyUsed = Object.keys(this.ultimatesUsed).some(id =>
+        this.ultimatesUsed[id]
+      );
+
+      if (anyUsed) {
+        button.classList.remove('ready');
+        button.classList.add('used');
+        button.disabled = true;
+      } else if (anyReady) {
+        button.classList.add('ready');
+        button.classList.remove('used');
+        button.disabled = false;
+      } else {
+        button.classList.remove('ready', 'used');
+        button.disabled = true;
+      }
+    },
+
+    /**
+     * Track when a unit uses a ninjutsu (resets basic attack count)
+     * @param {string} unitId - Unit identifier
+     */
+    onNinjutsuUse(unitId) {
+      if (this.basicAttackCounts.hasOwnProperty(unitId)) {
+        console.log(`[BattleEquippedUltimate] ${unitId} used ninjutsu - resetting basic attack count`);
+        this.basicAttackCounts[unitId] = 0;
+        this.ultimateReady[unitId] = false;
+
+        // Update UI
+        this.updateProgressUI(unitId);
+        this.updateButtonUI();
+      }
+    },
+
+    /**
+     * Check if a unit can use their equipped ultimate
+     * @param {string} unitId - Unit identifier
+     * @returns {boolean}
+     */
+    canUseUltimate(unitId) {
+      return this.ultimateReady[unitId] === true && this.ultimatesUsed[unitId] === false;
+    },
+
+    /**
+     * Get equipped ultimate data for a unit
+     * @param {Object} unit - Battle unit object
+     * @returns {Object|null} Ultimate data or null
+     */
+    getEquippedUltimateData(unit) {
+      if (!unit || !unit.originalId) return null;
+      if (typeof window.CharacterEquip === 'undefined') return null;
+
+      const ultimateId = window.CharacterEquip.getEquippedUltimate(unit.originalId);
+      if (!ultimateId) return null;
+
+      const ultimateData = window.CharacterEquip.getUltimateData(ultimateId);
+      return ultimateData;
+    },
+
+    /**
+     * Use equipped ultimate
+     * @param {string} unitId - Unit identifier
+     * @param {Object} ultimate - Ultimate data
+     * @param {Array} targets - Target units
+     * @returns {Object} Result of ultimate use
+     */
+    async useUltimate(unitId, ultimate, targets) {
+      if (!this.canUseUltimate(unitId)) {
+        console.warn(`[BattleEquippedUltimate] ${unitId} cannot use ultimate yet`);
+        return { success: false, reason: "Not ready or already used" };
+      }
+
+      // Mark as used
+      this.ultimatesUsed[unitId] = true;
+      this.ultimateReady[unitId] = false;
+      this.basicAttackCounts[unitId] = 0;
+
+      console.log(`[BattleEquippedUltimate] ${unitId} using equipped ultimate: ${ultimate.name}`);
+
+      // Show attack name (Storm 4 style)
+      if (window.BattleAttackNames) {
+        window.BattleAttackNames.showAttackName(ultimate.name, 'ultimate');
+      }
+
+      // Apply ultimate effects
+      const result = await this.applyUltimateEffects(unitId, ultimate, targets);
+
+      // Show notification
+      this.showUltimateNotification(ultimate);
+
+      // Update team HP and check battle end
+      if (this.core) {
+        setTimeout(() => {
+          this.core.updateTeamHP();
+          this.core.checkBattleEnd();
+        }, 500);
+      }
+
+      return { success: true, result };
+    },
+
+    /**
+     * Apply ultimate effects to targets
+     * @param {string} userId - User ID
+     * @param {Object} ultimate - Ultimate data
+     * @param {Array} targets - Target units
+     * @returns {Object} Effect results
+     */
+    async applyUltimateEffects(userId, ultimate, targets) {
+      const results = {
+        damage: [],
+        healing: [],
+        buffs: [],
+        debuffs: []
+      };
+
+      // Find the attacker unit
+      const attacker = this.core?.activeTeam?.find(u => u.id === userId);
+      if (!attacker) {
+        console.error('[BattleEquippedUltimate] Could not find attacker unit');
+        return results;
+      }
+
+      for (const effect of ultimate.effects) {
+        switch (effect.type) {
+          case 'damage':
+            // Apply damage to targets using BattleCombat
+            for (const target of targets) {
+              if (window.BattleCombat && this.core) {
+                const { damage, isCritical } = window.BattleCombat.calculateDamage(
+                  attacker,
+                  target,
+                  effect.multiplier || 1.0
+                );
+
+                // Apply damage directly
+                target.stats.hp = Math.max(0, target.stats.hp - damage);
+                results.damage.push({ target: target.id, amount: damage });
+
+                // Show damage animation
+                if (window.BattleAnimations) {
+                  setTimeout(() => {
+                    window.BattleAnimations.showDamage(target, damage, isCritical, this.core.dom);
+                  }, 100);
+                }
+
+                // Update unit display
+                if (this.core.units) {
+                  this.core.units.updateUnitDisplay(target, this.core);
+                }
+              }
+            }
+            break;
+
+          case 'multi_hit':
+            // Multi-hit attack
+            for (let i = 0; i < effect.hits; i++) {
+              for (const target of targets) {
+                if (window.BattleCombat && this.core) {
+                  const { damage, isCritical } = window.BattleCombat.calculateDamage(
+                    attacker,
+                    target,
+                    effect.multiplier || 1.0
+                  );
+
+                  // Apply damage
+                  target.stats.hp = Math.max(0, target.stats.hp - damage);
+                  results.damage.push({ target: target.id, amount: damage, hit: i + 1 });
+
+                  // Show damage animation with delay
+                  const delay = i * 200;
+                  setTimeout(() => {
+                    if (window.BattleAnimations) {
+                      window.BattleAnimations.showDamage(target, damage, isCritical, this.core.dom);
+                    }
+                  }, delay);
+
+                  // Update display
+                  if (this.core.units) {
+                    this.core.units.updateUnitDisplay(target, this.core);
+                  }
+
+                  // Wait between hits
+                  await new Promise(resolve => setTimeout(resolve, 200));
+                }
+              }
+            }
+            break;
+
+          case 'heal':
+            // Heal targets
+            for (const target of targets) {
+              const maxHP = target.stats?.maxHP || target.stats?.hp || 1000;
+              const healAmount = Math.floor(maxHP * (effect.percent || 0.3));
+              results.healing.push({ target: target.id, amount: healAmount });
+
+              if (target.stats) {
+                target.stats.hp = Math.min(target.stats.hp + healAmount, maxHP);
+
+                // Show heal animation
+                if (window.BattleAnimations) {
+                  setTimeout(() => {
+                    window.BattleAnimations.showDamage(target, -healAmount, false, this.core.dom);
+                  }, 100);
+                }
+
+                // Update display
+                if (this.core.units) {
+                  this.core.units.updateUnitDisplay(target, this.core);
+                }
+              }
+            }
+            break;
+
+          case 'buff':
+            // Apply buff
+            for (const target of targets) {
+              results.buffs.push({
+                target: target.id,
+                stat: effect.stat,
+                multiplier: effect.multiplier,
+                duration: effect.duration
+              });
+
+              // Apply buff if BattleBuffs is available
+              if (typeof window.BattleBuffs !== 'undefined' && window.BattleBuffs.applyBuff) {
+                window.BattleBuffs.applyBuff(target, effect.stat, effect.multiplier, effect.duration);
+              }
+            }
+            break;
+
+          case 'debuff':
+            // Apply debuff
+            for (const target of targets) {
+              results.debuffs.push({
+                target: target.id,
+                status: effect.status || effect.stat,
+                duration: effect.duration
+              });
+
+              // Apply debuff if BattleBuffs is available
+              if (typeof window.BattleBuffs !== 'undefined' && window.BattleBuffs.applyDebuff) {
+                window.BattleBuffs.applyDebuff(target, effect.status || effect.stat, effect.duration);
+              }
+            }
+            break;
+
+          case 'cleanse':
+            // Remove debuffs
+            for (const target of targets) {
+              if (typeof window.BattleBuffs !== 'undefined' && window.BattleBuffs.cleanse) {
+                window.BattleBuffs.cleanse(target);
+              }
+            }
+            break;
+        }
+      }
+
+      return results;
+    },
+
+    /**
+     * Calculate damage for ultimate effect
+     * @param {string} userId - Attacker ID
+     * @param {Object} target - Target unit
+     * @param {Object} effect - Effect data
+     * @returns {number} Damage amount
+     */
+    calculateDamage(userId, target, effect) {
+      // Get attacker (simplified - should fetch from BattleCore.combatants)
+      const attacker = { atk: 500 }; // Placeholder - replace with actual unit lookup
+
+      let damage = attacker.atk * (effect.multiplier || 1);
+
+      // Apply defense reduction
+      if (effect.ignoreDefense) {
+        const defenseReduction = target.def ? target.def * (1 - effect.ignoreDefense) : 0;
+        damage = damage - defenseReduction;
+      } else {
+        damage = damage - (target.def || 0);
+      }
+
+      // Guaranteed crit
+      if (effect.guaranteedCrit) {
+        damage *= 1.5;
+      }
+
+      return Math.max(Math.floor(damage), 1);
+    },
+
+    /**
+     * Notify that ultimate is ready
+     * @param {string} unitId - Unit identifier
+     */
+    notifyUltimateReady(unitId) {
+      console.log(`[BattleEquippedUltimate] 🔥 ULTIMATE READY for ${unitId}!`);
+
+      // Show visual indicator on unit
+      const unitElement = document.querySelector(`[data-unit-id="${unitId}"]`);
+      if (unitElement) {
+        unitElement.classList.add('ultimate-ready');
+
+        // Add glowing effect
+        const indicator = document.createElement('div');
+        indicator.className = 'ultimate-ready-indicator';
+        indicator.textContent = '⚡ ULTIMATE READY!';
+        unitElement.appendChild(indicator);
+      }
+
+      // Update button UI
+      this.updateButtonUI();
+    },
+
+    /**
+     * Show ultimate activation notification
+     * @param {Object} ultimate - Ultimate data
+     */
+    showUltimateNotification(ultimate) {
+      // Create notification element
+      const notification = document.createElement('div');
+      notification.className = 'equipped-ultimate-notification';
+      notification.innerHTML = `
+        <div class="ultimate-notification-icon">${ultimate.icon}</div>
+        <div class="ultimate-notification-text">
+          <div class="ultimate-notification-title">${ultimate.name}</div>
+          <div class="ultimate-notification-desc">${ultimate.description}</div>
+        </div>
+      `;
+
+      document.body.appendChild(notification);
+
+      // Animate in
+      setTimeout(() => notification.classList.add('show'), 100);
+
+      // Remove after 3 seconds
+      setTimeout(() => {
+        notification.classList.remove('show');
+        setTimeout(() => notification.remove(), 300);
+      }, 3000);
+    },
+
+    /**
+     * Reset state for new battle
+     */
+    reset() {
+      console.log("[BattleEquippedUltimate] Resetting state");
+      this.basicAttackCounts = {};
+      this.ultimatesUsed = {};
+      this.ultimateReady = {};
+    }
+  };
+
+  // Export to global
+  window.BattleEquippedUltimate = BattleEquippedUltimate;
+})();

--- a/js/character-equip.js
+++ b/js/character-equip.js
@@ -7,91 +7,31 @@
 
   const STORAGE_KEY = "blazing_character_equip_v1";
 
-  // Ultimate Abilities Database
-  const ULTIMATES = {
-    "rasengan_ultimate": {
-      id: "rasengan_ultimate",
-      name: "Massive Rasengan",
-      description: "Unleash a massive chakra sphere that deals 500% ATK damage to all enemies and ignores 50% of their defense.",
-      icon: "💥",
-      chakraCost: 10,
-      power: 500,
-      target: "all_enemies",
-      effects: ["ignore_defense_50", "stun_20_percent"]
-    },
-    "chidori_ultimate": {
-      id: "chidori_ultimate",
-      name: "Lightning Blade",
-      description: "Channel lightning through your hand for a devastating strike dealing 600% ATK damage with guaranteed critical hit.",
-      icon: "⚡",
-      chakraCost: 10,
-      power: 600,
-      target: "single_enemy",
-      effects: ["guaranteed_crit", "pierce"]
-    },
-    "sharingan_ultimate": {
-      id: "sharingan_ultimate",
-      name: "Mangekyō Sharingan",
-      description: "Activate Mangekyō Sharingan to buff all allies with +100% ATK and +50% Speed for 3 turns.",
-      icon: "👁️",
-      chakraCost: 12,
-      power: 0,
-      target: "all_allies",
-      effects: ["atk_buff_100_3turns", "speed_buff_50_3turns"]
-    },
-    "sage_mode_ultimate": {
-      id: "sage_mode_ultimate",
-      name: "Sage Mode Activation",
-      description: "Enter Sage Mode, healing all allies for 30% HP and granting immunity to debuffs for 2 turns.",
-      icon: "🟠",
-      chakraCost: 15,
-      power: 0,
-      target: "all_allies",
-      effects: ["heal_30_percent", "debuff_immunity_2turns"]
-    },
-    "shadow_clone_ultimate": {
-      id: "shadow_clone_ultimate",
-      name: "Multi Shadow Clone Jutsu",
-      description: "Create shadow clones to attack all enemies 5 times dealing 200% ATK damage each hit.",
-      icon: "👥",
-      chakraCost: 12,
-      power: 200,
-      target: "all_enemies",
-      effects: ["multi_hit_5", "confusion_chance_30"]
-    },
-    "fire_style_ultimate": {
-      id: "fire_style_ultimate",
-      name: "Great Fire Annihilation",
-      description: "Unleash massive flames dealing 450% ATK damage to all enemies and inflicting burn for 3 turns.",
-      icon: "🔥",
-      chakraCost: 11,
-      power: 450,
-      target: "all_enemies",
-      effects: ["burn_3turns", "reduce_defense_30_3turns"]
-    },
-    "byakugan_ultimate": {
-      id: "byakugan_ultimate",
-      name: "Eight Trigrams Sixty-Four Palms",
-      description: "Precise chakra point strikes dealing 550% ATK damage and sealing the target's ninjutsu for 2 turns.",
-      icon: "👁️‍🗨️",
-      chakraCost: 13,
-      power: 550,
-      target: "single_enemy",
-      effects: ["ninjutsu_seal_2turns", "chakra_drain_50_percent"]
-    },
-    "healing_ultimate": {
-      id: "healing_ultimate",
-      name: "Mystical Palm Technique",
-      description: "Advanced medical ninjutsu that heals all allies for 50% HP and removes all debuffs.",
-      icon: "💚",
-      chakraCost: 14,
-      power: 0,
-      target: "all_allies",
-      effects: ["heal_50_percent", "remove_all_debuffs", "regen_3turns"]
-    }
-  };
-
+  let _ultimates = {};
   let _equipData = {};
+  let _loaded = false;
+
+  // ---------- Load Ultimates from JSON ----------
+  async function loadUltimatesJSON() {
+    try {
+      const response = await fetch('data/equip-ultimates.json');
+      const data = await response.json();
+
+      // Convert array to object keyed by ID
+      _ultimates = {};
+      data.ultimates.forEach(ult => {
+        _ultimates[ult.id] = ult;
+      });
+
+      _loaded = true;
+      console.log(`[CharacterEquip] Loaded ${data.ultimates.length} equip ultimates from JSON`);
+      return true;
+    } catch (err) {
+      console.error("[CharacterEquip] Failed to load ultimates JSON:", err);
+      _loaded = false;
+      return false;
+    }
+  }
 
   // ---------- Persistence ----------
   function loadEquipData() {
@@ -118,7 +58,7 @@
   }
 
   function equipUltimate(characterId, ultimateId) {
-    if (!ULTIMATES[ultimateId]) {
+    if (!_ultimates[ultimateId]) {
       console.error(`[CharacterEquip] Unknown ultimate: ${ultimateId}`);
       return false;
     }
@@ -137,11 +77,15 @@
   }
 
   function getUltimateData(ultimateId) {
-    return ULTIMATES[ultimateId] || null;
+    return _ultimates[ultimateId] || null;
   }
 
   function getAllUltimates() {
-    return { ...ULTIMATES };
+    return { ..._ultimates };
+  }
+
+  function isLoaded() {
+    return _loaded;
   }
 
   // ---------- UI Update Functions ----------
@@ -221,7 +165,13 @@
   }
 
   // Initialize on load
-  loadEquipData();
+  async function init() {
+    await loadUltimatesJSON();
+    loadEquipData();
+  }
+
+  // Auto-initialize
+  init();
 
   // Public API
   global.CharacterEquip = {
@@ -233,7 +183,8 @@
     updateEquipUI,
     openUltimateSelector,
     initEquipTab,
-    ULTIMATES
+    isLoaded,
+    loadUltimatesJSON
   };
 
 })(window);


### PR DESCRIPTION
Implemented complete equipped ultimate system that allows once-per-battle ultimates unlocked after 3 consecutive basic attacks:

**JSON Data System:**
- Created data/equip-ultimates.json with 8 equippable ultimates
- Each ultimate has effects array (damage, multi_hit, heal, buff, debuff, cleanse)
- Unlock requirement: 3 consecutive basic attacks

**Character Equipment:**
- Modified js/character-equip.js to load ultimates from JSON (not hardcoded)
- Added loadUltimatesJSON() async function
- Converted ULTIMATES object to _ultimates variable populated from JSON

**Battle Integration:**
- Created js/battle/battle-equipped-ultimate.js with complete tracking system
- Tracks basic attack count per unit (resets to 0 on ninjutsu use)
- Tracks ultimate ready state and used state (once per battle)
- Implements proper damage calculation using BattleCombat system
- Supports all effect types: damage, multi_hit, heal, buff, debuff, cleanse

**Battle Combat Hooks:**
- Modified js/battle/battle-combat.js to track basic attacks:
  - performAttack() calls onBasicAttack()
  - performMultiAttack() calls onBasicAttack()
- Modified js/battle/battle-combat.js to reset on ninjutsu:
  - performJutsu() calls onNinjutsuUse()
  - performMultiJutsu() calls onNinjutsuUse()

**Battle System:**
- Updated js/battle.js required modules list
- Initialize BattleEquippedUltimate with core reference
- Register all player units for tracking on battle start

**UI Implementation:**
- Added equipped ultimate button to battle.html
- Created css/battle-equipped-ultimate.css with 3 button states:
  - Disabled (gray, 0-2 basic attacks)
  - Ready (gold glow, 3+ basic attacks)
  - Used (dark gray, ultimate already used)
- Progress indicator shows "X / 3 Basic Attacks"
- Ultimate ready indicator appears on unit sprite
- Full-screen notification on ultimate activation
- Attack name display integration (Storm 4 style)

**Features:**
- Once-per-battle enforcement
- Requires 3 consecutive basic attacks to unlock
- Resets counter when ninjutsu is used
- Visual feedback with glowing effects
- Proper damage calculations and animations
- Team HP update and battle end check after use