### PR TITLE
fix: increase banner buttons 20% and fix summon carousel display

### DIFF
--- a/css/ui-layout.css
+++ b/css/ui-layout.css
@@ -14,10 +14,10 @@
   z-index: 50;
   display: grid;
   grid-template-columns: 1fr 1fr; /* Two equal columns */
-  grid-auto-rows: 78px; /* Increased 15%: 68px × 1.15 = 78px */
+  grid-auto-rows: 94px; /* Increased 20%: 78px × 1.20 = 94px */
   gap: 12px; /* 12px spacing between all buttons - MAINTAINED */
   pointer-events: auto;
-  width: 248px; /* Increased 15%: 216px × 1.15 = 248px */
+  width: 298px; /* Increased 20%: 248px × 1.20 = 298px */
   margin-right: 50px; /* Space from screen edge */
 }
 
@@ -28,7 +28,7 @@
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  border-radius: 5px; /* Increased 15%: 4px × 1.15 = 5px */
+  border-radius: 6px; /* Increased 20%: 5px × 1.20 = 6px */
   cursor: pointer;
   transition: all 0.3s ease;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
@@ -39,8 +39,8 @@
 
 /* Missions banner spans both columns (full width) */
 .banner-button.missions {
-  grid-column: 1 / 3; /* Span both columns (full 248px width with 12px gap) */
-  height: 78px; /* Increased 15%: 68px × 1.15 = 78px */
+  grid-column: 1 / 3; /* Span both columns (full 298px width with 12px gap) */
+  height: 94px; /* Increased 20%: 78px × 1.20 = 94px */
 }
 
 /* Explicit grid positioning for 2×2 layout below Missions */
@@ -114,13 +114,13 @@
 /* Banner text overlay (temporary until PNGs have text) */
 .banner-button-text {
   position: absolute;
-  bottom: 8px; /* Increased 15%: 7px × 1.15 = 8px */
-  left: 10px; /* Increased 15%: 9px × 1.15 = 10px */
-  font-size: 13px; /* Increased 15%: 11px × 1.15 = 13px */
+  bottom: 10px; /* Increased 20%: 8px × 1.20 = 10px */
+  left: 12px; /* Increased 20%: 10px × 1.20 = 12px */
+  font-size: 16px; /* Increased 20%: 13px × 1.20 = 16px */
   font-weight: 700;
   color: #fff;
   text-shadow: 0 1px 4px rgba(0, 0, 0, 0.9);
-  letter-spacing: 0.5px; /* Increased 15%: 0.4px × 1.15 = 0.5px */
+  letter-spacing: 0.6px; /* Increased 20%: 0.5px × 1.20 = 0.6px */
   font-family: "Cinzel", serif;
 }
 
@@ -271,17 +271,38 @@
 .summon-banner-card {
   width: 266px; /* Reduced 30%: 380px × 0.7 = 266px */
   height: 126px; /* Reduced 30%: 180px × 0.7 = 126px */
-  background-image: linear-gradient(135deg, rgba(100, 50, 150, 0.6), rgba(150, 100, 200, 0.8)); /* Fallback gradient - will be replaced by JS */
+  background-image: linear-gradient(135deg, rgba(80, 40, 120, 0.9), rgba(120, 60, 180, 0.95)); /* Default fallback */
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  border-radius: 8px; /* Reduced from 12px */
+  border-radius: 8px;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.6); /* Reduced from 6px 20px */
-  border: 3px solid rgba(200, 100, 255, 0.6); /* Increased from 2px for better visibility */
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.6);
+  border: 3px solid rgba(200, 100, 255, 0.8);
   position: relative;
   overflow: hidden;
+}
+
+/* Gradient fallbacks for different banner types */
+.summon-banner-card.banner-type-blazing-festival {
+  background-image: linear-gradient(135deg, rgba(180, 20, 20, 0.9), rgba(220, 60, 60, 0.95));
+  border-color: rgba(255, 100, 100, 0.8);
+}
+
+.summon-banner-card.banner-type-blazing-bash {
+  background-image: linear-gradient(135deg, rgba(20, 80, 180, 0.9), rgba(60, 120, 220, 0.95));
+  border-color: rgba(100, 150, 255, 0.8);
+}
+
+.summon-banner-card.banner-type-anniversary {
+  background-image: linear-gradient(135deg, rgba(180, 120, 20, 0.9), rgba(220, 160, 60, 0.95));
+  border-color: rgba(255, 200, 100, 0.8);
+}
+
+.summon-banner-card.banner-type-birthday {
+  background-image: linear-gradient(135deg, rgba(180, 20, 120, 0.9), rgba(220, 60, 160, 0.95));
+  border-color: rgba(255, 100, 200, 0.8);
 }
 
 .summon-banner-card:hover {

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -185,17 +185,28 @@
       carousel.innerHTML = '';
 
       // Create banner cards
-      summonsData.banners.forEach(banner => {
+      summonsData.banners.forEach((banner, index) => {
         const card = document.createElement('div');
         card.className = 'summon-banner-card';
         card.dataset.bannerId = banner.id;
 
-        // Set background image from banner data
+        // Add banner type class for different gradient styles
+        if (banner.type) {
+          card.classList.add(`banner-type-${banner.type}`);
+        }
+
+        // Set background image from banner data (if it exists)
         if (banner.image) {
-          card.style.backgroundImage = `url("${banner.image}")`;
-          console.log(`[Summon] Setting background for ${banner.name}: ${banner.image}`);
-        } else {
-          console.warn(`[Summon] No image path for banner: ${banner.name}`);
+          // Try to preload the image to check if it exists
+          const img = new Image();
+          img.onload = () => {
+            card.style.backgroundImage = `url("${banner.image}")`;
+            console.log(`[Summon] ✓ Loaded image: ${banner.image}`);
+          };
+          img.onerror = () => {
+            console.warn(`[Summon] ✗ Image not found: ${banner.image} - using gradient fallback`);
+          };
+          img.src = banner.image;
         }
 
         // Add title
@@ -204,13 +215,11 @@
         title.textContent = banner.name;
         card.appendChild(title);
 
-        // Add subtitle (if exists)
-        if (banner.subtitle) {
-          const subtitle = document.createElement('div');
-          subtitle.className = 'summon-banner-subtitle';
-          subtitle.textContent = banner.subtitle;
-          card.appendChild(subtitle);
-        }
+        // Add subtitle/description
+        const subtitle = document.createElement('div');
+        subtitle.className = 'summon-banner-subtitle';
+        subtitle.textContent = banner.description || banner.subtitle || '';
+        card.appendChild(subtitle);
 
         // Click handler - navigate to summon.html with banner ID
         card.addEventListener('click', () => {


### PR DESCRIPTION
Banner Button Size Increase (20% larger):
- Panel width: 248px → 298px
- Row height: 78px → 94px
- Missions height: 78px → 94px
- Border radius: 5px → 6px
- Text font size: 13px → 16px
- Text bottom: 8px → 10px
- Text left: 10px → 12px
- Letter spacing: 0.5px → 0.6px
- Gap: 12px (MAINTAINED - no change)

Each column is now ~143px wide ((298px - 12px) / 2).

Summon Carousel Fixes (Purple Lines Issue):
Root Cause: Banner images don't exist yet (only .txt placeholders in assets/summon/banners/)

Solutions Implemented:
1. Image preloading with error handling - checks if image exists before setting
2. Console logging: ✓ for successful loads, ✗ for failures
3. Type-based gradient fallbacks instead of plain purple:
   - Blazing Festival: Red gradient (rgba(180,20,20) → rgba(220,60,60))
   - Blazing Bash: Blue gradient (rgba(20,80,180) → rgba(60,120,220))
   - Anniversary: Gold gradient (rgba(180,120,20) → rgba(220,160,60))
   - Birthday: Pink gradient (rgba(180,20,120) → rgba(220,60,160))
   - Default: Purple gradient (rgba(80,40,120) → rgba(120,60,180))
4. Always show description/subtitle text on cards
5. Improved border colors matching gradient types

Now shows colorful, distinguishable cards with text instead of "purple lines" until actual banner PNG images are added to assets/summon/banners/.