### PR TITLE
fix: make summon banner carousel visual-only (non-clickable)

### DIFF
--- a/css/summon-banner-carousel.css
+++ b/css/summon-banner-carousel.css
@@ -24,7 +24,7 @@
 
 .banner-slide.active {
   opacity: 1;
-  pointer-events: auto;
+  pointer-events: none; /* Disabled - banner is visual only */
   z-index: 1;
 }
 
@@ -56,13 +56,13 @@
   display: block;
 }
 
-/* Banner Navigation Dots */
+/* Banner Navigation Dots - HIDDEN (visual only mode) */
 .banner-nav-dots {
   position: absolute;
   bottom: 20px;
   left: 50%;
   transform: translateX(-50%);
-  display: flex;
+  display: none; /* Hidden - banner is visual only */
   gap: 10px;
   z-index: 10;
 }
@@ -73,7 +73,7 @@
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.3);
   border: 2px solid rgba(255, 255, 255, 0.5);
-  cursor: pointer;
+  cursor: default; /* Disabled - banner is visual only */
   transition: all 0.3s ease;
 }
 
@@ -89,7 +89,7 @@
   transform: scale(1.3);
 }
 
-/* Banner Arrow Controls */
+/* Banner Arrow Controls - HIDDEN (visual only mode) */
 .banner-arrow {
   position: absolute;
   top: 50%;
@@ -101,10 +101,10 @@
   width: 50px;
   height: 50px;
   border-radius: 50%;
-  display: flex;
+  display: none; /* Hidden - banner is visual only */
   align-items: center;
   justify-content: center;
-  cursor: pointer;
+  cursor: default; /* Disabled - banner is visual only */
   z-index: 10;
   transition: all 0.3s ease;
   backdrop-filter: blur(5px);

--- a/css/ui-layout.css
+++ b/css/ui-layout.css
@@ -241,7 +241,7 @@
   background: rgba(212, 175, 55, 0.8);
 }
 
-/* Individual summon banner card */
+/* Individual summon banner card - VISUAL ONLY (non-clickable) */
 .summon-banner-card {
   width: 380px;
   height: 180px;
@@ -249,7 +249,8 @@
   background-position: center;
   background-repeat: no-repeat;
   border-radius: 12px;
-  cursor: pointer;
+  cursor: default; /* Disabled - banner is visual only */
+  pointer-events: none; /* Disabled - banner is visual only */
   transition: all 0.3s ease;
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.6);
   border: 3px solid rgba(200, 100, 255, 0.4);
@@ -257,15 +258,16 @@
   overflow: hidden;
 }
 
-.summon-banner-card:hover {
+/* Hover and active effects DISABLED - visual only mode */
+/* .summon-banner-card:hover {
   transform: translateX(10px) scale(1.05);
   box-shadow: 0 8px 30px rgba(200, 100, 255, 0.7);
   border-color: rgba(200, 100, 255, 0.9);
-}
+} */
 
-.summon-banner-card:active {
+/* .summon-banner-card:active {
   transform: translateX(5px) scale(1.02);
-}
+} */
 
 /* Banner card glow */
 .summon-banner-card::before {
@@ -278,9 +280,10 @@
   pointer-events: none;
 }
 
-.summon-banner-card:hover::before {
+/* Hover glow DISABLED - visual only mode */
+/* .summon-banner-card:hover::before {
   opacity: 1;
-}
+} */
 
 /* Banner card title */
 .summon-banner-title {

--- a/js/dashboard-banner-slideshow.js
+++ b/js/dashboard-banner-slideshow.js
@@ -104,30 +104,31 @@ class DashboardBannerSlideshow {
   }
 
   attachEventListeners() {
-    // Arrow controls
-    const leftArrow = document.getElementById('dashboard-banner-arrow-left');
-    const rightArrow = document.getElementById('dashboard-banner-arrow-right');
+    // ===== INTERACTIVE CONTROLS DISABLED - Visual only mode =====
+    // Arrow controls - DISABLED
+    // const leftArrow = document.getElementById('dashboard-banner-arrow-left');
+    // const rightArrow = document.getElementById('dashboard-banner-arrow-right');
 
-    if (leftArrow) {
-      leftArrow.addEventListener('click', () => this.previous());
-    }
+    // if (leftArrow) {
+    //   leftArrow.addEventListener('click', () => this.previous());
+    // }
 
-    if (rightArrow) {
-      rightArrow.addEventListener('click', () => this.next());
-    }
+    // if (rightArrow) {
+    //   rightArrow.addEventListener('click', () => this.next());
+    // }
 
-    // Dot navigation
-    const dots = this.container.querySelectorAll('.banner-dot');
-    dots.forEach(dot => {
-      dot.addEventListener('click', () => {
-        const index = parseInt(dot.dataset.index);
-        this.goToSlide(index);
-      });
-    });
+    // Dot navigation - DISABLED
+    // const dots = this.container.querySelectorAll('.banner-dot');
+    // dots.forEach(dot => {
+    //   dot.addEventListener('click', () => {
+    //     const index = parseInt(dot.dataset.index);
+    //     this.goToSlide(index);
+    //   });
+    // });
 
-    // Pause on hover
-    this.container.addEventListener('mouseenter', () => this.pauseAutoAdvance());
-    this.container.addEventListener('mouseleave', () => this.resumeAutoAdvance());
+    // Pause on hover - DISABLED (auto-advance continues regardless of mouse)
+    // this.container.addEventListener('mouseenter', () => this.pauseAutoAdvance());
+    // this.container.addEventListener('mouseleave', () => this.resumeAutoAdvance());
   }
 
   next() {

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -204,11 +204,11 @@
           card.appendChild(subtitle);
         }
 
-        // Click handler - navigate to summon.html with banner ID
-        card.addEventListener('click', () => {
-          console.log(`🔮 Summon banner clicked: ${banner.name}`);
-          navigateTo('summon.html', { banner: banner.id });
-        });
+        // Click handler disabled - banner is visual only
+        // card.addEventListener('click', () => {
+        //   console.log(`🔮 Summon banner clicked: ${banner.name}`);
+        //   navigateTo('summon.html', { banner: banner.id });
+        // });
 
         carousel.appendChild(card);
       });


### PR DESCRIPTION
Disabled all interactive functionality from the banner carousel on index.html to prevent clickable UI elements that were causing aesthetic issues.

Changes:
- js/navigation.js: Disabled click event listener on banner cards
- css/ui-layout.css: Removed hover/active effects, added pointer-events: none
- css/summon-banner-carousel.css: Hidden arrow and dot navigation controls
- js/dashboard-banner-slideshow.js: Disabled all interactive event listeners

The banner carousel now displays banners purely for visual presentation without any clickable elements or hover effects.