### PR TITLE
feat: implement background music auto-play on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -512,6 +512,38 @@
         }
       }
 
+      // ===== MUSIC INITIALIZATION =====
+      // Start background music using AudioManager
+      if (typeof window.AudioManager !== 'undefined') {
+        console.log('🎵 Starting background music...');
+
+        // Try to play after user interaction
+        const startMusic = () => {
+          const bgm = window.AudioManager.playBGM('assets/music/general.mp3');
+          if (bgm) {
+            console.log('🎵 Background music started successfully');
+          } else {
+            console.log('⚠️ Background music failed to start');
+          }
+        };
+
+        // Add one-time click listener to start music
+        document.addEventListener('click', () => {
+          if (!window.AudioManager.currentBGM) {
+            startMusic();
+          }
+        }, { once: true });
+
+        // Also try immediately (may be blocked by browser autoplay policy)
+        setTimeout(() => {
+          if (!window.AudioManager.currentBGM) {
+            startMusic();
+          }
+        }, 1000);
+      } else {
+        console.error('❌ AudioManager not found - music cannot play');
+      }
+
       console.log("✅ All systems initialized!");
     });
   </script>


### PR DESCRIPTION
- Use AudioManager.playBGM() to start assets/music/general.mp3
- Try auto-play after 1 second delay
- Add click listener to start music on first user interaction (bypasses autoplay restrictions)
- Log music initialization status for debugging

This integrates with the AudioManager system that was merged from remote branch.