### PR TITLE
fix: add AudioManager script to all pages for music playback

### DIFF
--- a/characters.html
+++ b/characters.html
@@ -202,6 +202,7 @@
   </div>
 
   <!-- Core Scripts -->
+  <script src="js/audio-manager.js"></script>
   <script src="js/music-player.js"></script>
   <script src="js/character_inv.js"></script>
   <script src="js/progression.js"></script>

--- a/fusion.html
+++ b/fusion.html
@@ -146,6 +146,7 @@
   </div>
 
   <!-- Scripts -->
+  <script src="js/audio-manager.js"></script>
   <script src="js/music-player.js"></script>
   <script src="js/character_inv.js"></script>
   <script src="js/resources.js"></script>

--- a/inventory.html
+++ b/inventory.html
@@ -102,6 +102,7 @@
     </div>
   </div>
 
+  <script src="js/audio-manager.js"></script>
   <script src="js/resources.js"></script>
   <script src="js/inventory.js"></script>
   <script src="js/navigation.js"></script>

--- a/missions.html
+++ b/missions.html
@@ -51,6 +51,7 @@
     </div>
   </div>
 
+  <script src="js/audio-manager.js"></script>
   <script src="js/music-player.js"></script>
   <script src="js/resources.js"></script>
   <script src="js/mission-progress.js"></script>

--- a/resources.html
+++ b/resources.html
@@ -202,6 +202,7 @@
     </div>
   </div>
 
+  <script src="js/audio-manager.js"></script>
   <script src="js/music-player.js"></script>
   <script src="js/resources.js"></script>
 

--- a/shop.html
+++ b/shop.html
@@ -123,6 +123,7 @@
     </div>
   </div>
 
+  <script src="js/audio-manager.js"></script>
   <script src="js/resources.js"></script>
   <script defer src="js/shop.js"></script>
 

--- a/summon.html
+++ b/summon.html
@@ -202,6 +202,7 @@
   </div>
 
   <!-- Scripts -->
+  <script src="js/audio-manager.js"></script>
   <script src="js/music-player.js"></script>
   <script src="js/resources.js"></script>
   <script src="js/character_inv.js"></script>

--- a/teams.html
+++ b/teams.html
@@ -139,6 +139,7 @@
     </div>
   </div>
 
+  <script src="js/audio-manager.js"></script>
   <script src="js/music-player.js"></script>
   <script src="js/character_inv.js"></script>
   <script src="js/progression.js"></script>


### PR DESCRIPTION
Added <script src="js/audio-manager.js"></script> to all pages:
- characters.html
- missions.html
- summon.html
- shop.html
- fusion.html
- teams.html
- inventory.html
- resources.html

Previously, only index.html loaded AudioManager, causing music initialization to fail on other pages with "AudioManager is undefined".

Now all pages can properly initialize and play background music.