### PR TITLE
feat: expand username name holder by 80%

### DIFF
--- a/css/top-bar.css
+++ b/css/top-bar.css
@@ -61,8 +61,8 @@ body {
   justify-content: center;
   align-items: center;
   position: relative;
-  min-width: 200px;
-  max-width: 300px;
+  min-width: 360px;
+  max-width: 540px;
 }
 
 .username-holder {
@@ -70,8 +70,8 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 8px 30px;
-  min-width: 180px;
+  padding: 14px 54px;
+  min-width: 324px;
 }
 
 /* Name Holder Background PNG */
@@ -117,7 +117,7 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 240px;
+  max-width: 432px;
   transition: all 0.3s ease;
 }
 


### PR DESCRIPTION
- Increase .username-holder padding from 8px 30px to 14px 54px
- Increase .username-holder min-width from 180px to 324px
- Increase .username-container dimensions to accommodate larger holder
- Increase .username-text max-width from 240px to 432px
- All dimensions scaled by 1.8x for consistent 80% expansion