### PR TITLE
fix: change background-size from contain to 100% to properly scale PNG

### DIFF
--- a/css/top-bar.css
+++ b/css/top-bar.css
@@ -80,7 +80,7 @@ body {
   position: absolute;
   inset: 0;
   background-image: url("../assets/ui/name_holder.png");
-  background-size: contain;
+  background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
   opacity: 0.9;


### PR DESCRIPTION
- Changed background-size from 'contain' to '100% 100%' in .username-holder::before
- Ensures the name_holder.png stretches to fill the expanded container
- Combined with previous 80% container expansion, PNG now displays at full size