### PR TITLE
feat: make container thicker/shorter and remove gold gradient bubble

### DIFF
--- a/css/top-bar.css
+++ b/css/top-bar.css
@@ -61,8 +61,8 @@ body {
   justify-content: center;
   align-items: center;
   position: relative;
-  min-width: 300px;
-  max-width: 450px;
+  min-width: 260px;
+  max-width: 400px;
 }
 
 .username-holder {
@@ -70,8 +70,8 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 22px 40px;
-  min-width: 270px;
+  padding: 28px 32px;
+  min-width: 240px;
 }
 
 /* Name Holder Background PNG */
@@ -86,21 +86,7 @@ body {
   opacity: 0.9;
   z-index: 1;
   pointer-events: none;
-  /* Fallback gradient if PNG doesn't exist */
-  background-image:
-    url("../assets/ui/name_holder.png"),
-    linear-gradient(90deg,
-      rgba(139, 115, 85, 0.3) 0%,
-      rgba(212, 175, 55, 0.4) 15%,
-      rgba(212, 175, 55, 0.5) 50%,
-      rgba(212, 175, 55, 0.4) 85%,
-      rgba(139, 115, 85, 0.3) 100%
-    );
   border-radius: 20px;
-  box-shadow:
-    inset 0 2px 4px rgba(255, 255, 255, 0.1),
-    inset 0 -2px 4px rgba(0, 0, 0, 0.3),
-    0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
 .username-text {
@@ -117,7 +103,7 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 350px;
+  max-width: 300px;
   transition: all 0.3s ease;
 }
 


### PR DESCRIPTION
- Increase vertical padding: 22px → 28px (even thicker)
- Decrease horizontal padding: 40px → 32px (even shorter)
- Reduce min-width: 270px → 240px (more compact)
- Adjust container: min-width 300px→260px, max-width 450px→400px
- Reduce text max-width: 350px → 300px
- Remove gold gradient fallback background completely
- Remove box-shadow effects from ::before element
- Container now displays only the PNG with no gold bubble background