### PR TITLE
feat: implement click-based ramen selection and remove lightning emoji

### DIFF
--- a/characters.html
+++ b/characters.html
@@ -92,7 +92,6 @@
 
               <div class="equip-slot" id="equip-slot">
                 <div class="equip-slot-empty">
-                  <div class="equip-slot-icon">⚡</div>
                   <div class="equip-slot-text">No Ultimate Equipped</div>
                   <button class="btn-equip" id="btn-select-ultimate">Select Ultimate</button>
                 </div>

--- a/css/characters.css
+++ b/css/characters.css
@@ -1008,6 +1008,54 @@ body.page-characters {
   display: inline-block;
 }
 
+.ramen-counter {
+  font-family: 'Times New Roman', serif;
+  font-size: 16px;
+  font-weight: 700;
+  color: #666;
+  margin-top: 8px;
+  padding: 4px 12px;
+  background: rgba(0,0,0,0.3);
+  border-radius: 8px;
+  border: 2px solid rgba(100,100,100,0.3);
+  transition: all 0.3s ease;
+}
+
+.ramen-counter.active {
+  color: #ffd778;
+  border-color: rgba(255,215,120,0.6);
+  background: rgba(255,215,120,0.1);
+  box-shadow: 0 0 10px rgba(255,215,120,0.3);
+}
+
+.ramen-use-button {
+  grid-column: 1 / -1;
+  font-family: 'Cinzel', serif;
+  font-size: 16px;
+  font-weight: 700;
+  color: #ffd778;
+  background: linear-gradient(135deg, rgba(139,115,85,0.8), rgba(184,134,11,0.6));
+  border: 2px solid rgba(255,215,120,0.5);
+  border-radius: 10px;
+  padding: 14px 24px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  text-shadow: 1px 1px 2px rgba(0,0,0,0.8);
+  margin-top: 12px;
+}
+
+.ramen-use-button:hover {
+  background: linear-gradient(135deg, rgba(184,134,11,0.8), rgba(212,175,55,0.7));
+  border-color: rgba(255,215,120,0.8);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(255,215,120,0.4);
+}
+
+.ramen-use-button:active {
+  transform: translateY(0);
+  box-shadow: 0 3px 10px rgba(255,215,120,0.3);
+}
+
 .ramen-modal-actions {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
- Replace prompt-based ramen selection with click counting system
- Left-click to increment ramen count, right-click to decrement
- Add visual counter display on each ramen card
- Add 'Use Selected Ramen' button to process all selections at once
- Show total EXP calculation from all selected ramen
- Remove giant lightning emoji from equip slot in character page
- Add active state styling for selected ramen counters