### PR TITLE
fix: correct gift code character ID to match characters.json

### DIFF
--- a/data/gift-codes.json
+++ b/data/gift-codes.json
@@ -8,7 +8,7 @@
       "rewards": {
         "characters": [
           {
-            "characterId": "takimitsuha",
+            "characterId": "takimitsuha_1190",
             "quantity": 10,
             "tierCode": "7S"
           }


### PR DESCRIPTION
Changed characterId from "takimitsuha" to "takimitsuha_1190" to match the actual character ID in characters.json. This fixes the "missing character base" error when claiming gift code rewards.

Issue: Characters showed as "missing base" in character.html
Cause: Gift code referenced wrong character ID
Fix: Use correct ID "takimitsuha_1190" that exists in database