### PR TITLE
dev: allow multiple redemptions of same gift code for testing

### DIFF
--- a/js/gift-code-system.js
+++ b/js/gift-code-system.js
@@ -67,10 +67,11 @@ class GiftCodeSystem {
       return { success: false, message: 'Please enter a gift code.' };
     }
 
+    // [DEV] Allow multiple redemptions for development/testing
     // Check if already redeemed
-    if (this.isCodeRedeemed(code)) {
-      return { success: false, message: 'This code has already been redeemed.' };
-    }
+    // if (this.isCodeRedeemed(code)) {
+    //   return { success: false, message: 'This code has already been redeemed.' };
+    // }
 
     // Find code
     const codeData = this.findCode(code);
@@ -86,7 +87,7 @@ class GiftCodeSystem {
     // Redeem code - send rewards to mailbox
     await this.sendRewardsToMailbox(codeData);
 
-    // Mark as redeemed
+    // Mark as redeemed (still track for analytics, but doesn't block redemption)
     this.redeemedCodes.push({
       code: code,
       redeemedAt: new Date().toISOString()


### PR DESCRIPTION
Commented out the "already redeemed" check to allow developers to redeem the same gift code multiple times during development and testing. This makes it easier to test the gift code flow without having to create new codes or clear localStorage each time.

Changes:
- Disabled duplicate redemption prevention
- Added [DEV] comment to mark this as development-only behavior
- Still tracks redemption history for analytics
- Can easily be re-enabled for production by uncommenting lines 72-74

Note: For production, uncomment the isCodeRedeemed check to prevent abuse