### PR TITLE
fix: panel missions icon now opens modal instead of navigating to mis…

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -198,7 +198,11 @@
     if (iconPanelMissions) {
       iconPanelMissions.addEventListener('click', () => {
         console.log("[Navigation] Panel Missions clicked");
-        navigateTo('missions.html');
+        if (window.PanelMissions) {
+          window.PanelMissions.openPanelModal();
+        } else {
+          alert('Panel Missions system not loaded. Please reload the page.');
+        }
       });
     }
 


### PR DESCRIPTION
…sions.html

Changed navigation.js handler for panel-missions to call PanelMissions.openPanelModal() instead of navigating to missions.html. This displays the mission-panel.png background with a scrollable 3x3 reward grid as intended.