### PR TITLE
Add commander system to team setup

### DIFF
--- a/COMMANDER_SYSTEM.md
+++ b/COMMANDER_SYSTEM.md
@@ -1,0 +1,87 @@
+# Commander System Documentation
+
+## Overview
+The Commander System adds an off-field support unit to your team that provides passive buffs and an ultimate attack when certain conditions are met.
+
+## Features
+
+### 1. Commander Slot
+- Located below the Back Row formation
+- Commander does NOT participate in battle (off-field unit)
+- Only provides buffs and ultimate support
+
+### 2. Passive Team Buffs
+Buffs scale based on the commander's **Element** and **Star Rating**.
+
+#### Element-Based Buffs (Baseline at 5★)
+
+| Element  | Buff Type(s)                |
+|----------|-----------------------------|
+| Body     | +4% ATK                     |
+| Bravery  | +3% ATK, +1% Health         |
+| Wisdom   | +3% ATK, +1% Health         |
+| Heart    | +4% ATK                     |
+| Skill    | +4% Speed                   |
+
+#### Star Scaling
+- **5★**: Baseline buffs (as shown above)
+- **10★**: Maximum buffs (20% for all stats)
+- Linear scaling between 5★ and 10★
+
+**Example:**
+- 5★ Body Commander: +4% ATK
+- 7★ Body Commander: +10.4% ATK
+- 10★ Body Commander: +20% ATK
+
+### 3. Commander Ultimate
+- **Trigger Condition**: Team's collective chakra reaches 16
+- **Behavior**: Trigger only (does NOT consume chakra)
+- **Ultimate Data**: Pulled from character's `skills.ultimate` in `characters.json`
+- **Ultimate PNG**: Container implemented, PNG files to be added
+
+## Implementation Details
+
+### Required Character Data
+Each character in `data/characters.json` needs:
+```json
+{
+  "id": "character_id",
+  "element": "body|bravery|wisdom|heart|skill",
+  "skills": {
+    "ultimate": {
+      "name": "Ultimate Name",
+      "byTier": {
+        "6S": {
+          "description": "Ultimate description",
+          "chakraCost": 8,
+          "range": "All Enemies",
+          "hits": 10,
+          "multiplier": "15.0x ATK"
+        }
+      }
+    }
+  }
+}
+```
+
+### Storage Structure
+Commander data is stored in localStorage under `blazing_teams_v1`:
+```javascript
+{
+  "1": {
+    "front-1": { uid: "...", charId: "..." },
+    "commander": { uid: "...", charId: "..." }  // Commander slot
+  }
+}
+```
+
+## Files Modified
+- `/home/user/Naruto-Blazing/teams.html` - Added commander UI section
+- `/home/user/Naruto-Blazing/css/teams.css` - Added commander styling
+- `/home/user/Naruto-Blazing/js/team_manager.js` - Added commander logic
+
+## Future Work
+1. Add ultimate PNG images for each character
+2. Implement ultimate trigger system in battle
+3. Apply passive buffs to team stats in battle
+4. Visual effects for ultimate activation

--- a/css/teams.css
+++ b/css/teams.css
@@ -630,3 +630,208 @@ body.page-teams {
     background-color: rgba(20, 20, 30, 0.7);
     border: 2px solid rgba(255, 215, 120, 0.2);
 }
+
+/* ========================================
+ * Commander System Styling
+ * ======================================== */
+
+.commander-section {
+  margin-top: 30px;
+  padding-top: 20px;
+  border-top: 2px solid rgba(255, 215, 120, 0.2);
+}
+
+.commander-container {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 20px;
+  align-items: start;
+}
+
+.commander-slot {
+  width: 100%;
+  min-height: 260px;
+}
+
+.commander-info {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.commander-info h4 {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: var(--gold);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Commander Buffs Display */
+.commander-buffs {
+  background: rgba(20, 20, 24, 0.6);
+  border: 1px solid rgba(255, 215, 120, 0.15);
+  border-radius: 8px;
+  padding: 15px;
+}
+
+.buff-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.buff-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: rgba(217, 179, 98, 0.1);
+  border-left: 3px solid var(--gold);
+  border-radius: 4px;
+  font-size: 12px;
+  color: #eee6d1;
+}
+
+.buff-icon {
+  width: 20px;
+  height: 20px;
+  font-size: 16px;
+}
+
+.buff-text {
+  flex: 1;
+}
+
+.no-commander {
+  color: #888;
+  font-size: 12px;
+  text-align: center;
+  padding: 10px;
+}
+
+/* Commander Ultimate Display */
+.commander-ultimate {
+  background: rgba(20, 20, 24, 0.6);
+  border: 1px solid rgba(255, 215, 120, 0.15);
+  border-radius: 8px;
+  padding: 15px;
+}
+
+.ultimate-container {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 15px;
+  align-items: start;
+}
+
+.ultimate-image-container {
+  width: 150px;
+  height: 150px;
+  background: rgba(0, 0, 0, 0.4);
+  border: 2px solid rgba(255, 215, 120, 0.2);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+}
+
+.ultimate-image-container img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.no-ultimate {
+  color: #888;
+  font-size: 11px;
+  text-align: center;
+  padding: 10px;
+  line-height: 1.4;
+}
+
+.ultimate-info {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ultimate-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--gold);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.ultimate-description {
+  font-size: 12px;
+  color: #cfc2a0;
+  line-height: 1.5;
+}
+
+.ultimate-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 5px;
+}
+
+.ultimate-stat-badge {
+  padding: 4px 8px;
+  background: rgba(217, 179, 98, 0.15);
+  border: 1px solid rgba(217, 179, 98, 0.3);
+  border-radius: 4px;
+  font-size: 10px;
+  color: #ffe2a9;
+}
+
+/* Element-specific border colors for commander slot */
+.commander-slot[data-element="body"] {
+  border-color: rgba(255, 200, 100, 0.5);
+}
+
+.commander-slot[data-element="skill"] {
+  border-color: rgba(100, 150, 255, 0.5);
+}
+
+.commander-slot[data-element="bravery"] {
+  border-color: rgba(255, 150, 50, 0.5);
+}
+
+.commander-slot[data-element="wisdom"] {
+  border-color: rgba(150, 255, 150, 0.5);
+}
+
+.commander-slot[data-element="heart"] {
+  border-color: rgba(255, 100, 100, 0.5);
+}
+
+/* Responsive adjustments */
+@media (max-width: 1024px) {
+  .commander-container {
+    grid-template-columns: 1fr;
+  }
+
+  .ultimate-container {
+    grid-template-columns: 120px 1fr;
+  }
+
+  .ultimate-image-container {
+    width: 120px;
+    height: 120px;
+  }
+}
+
+@media (max-width: 768px) {
+  .ultimate-container {
+    grid-template-columns: 1fr;
+  }
+
+  .ultimate-image-container {
+    width: 100%;
+    height: 180px;
+  }
+}

--- a/teams.html
+++ b/teams.html
@@ -66,6 +66,35 @@
         </div>
       </div>
 
+      <div class="formation-section commander-section">
+        <h3 class="section-label">Commander (Off-Field Support)</h3>
+        <div class="commander-container">
+          <div class="team-slot commander-slot" data-slot="commander" data-type="commander">
+            <div class="slot-empty">Empty</div>
+          </div>
+          <div class="commander-info">
+            <div class="commander-buffs">
+              <h4>Team Buffs</h4>
+              <div id="commander-buff-display" class="buff-list">
+                <span class="no-commander">No commander assigned</span>
+              </div>
+            </div>
+            <div class="commander-ultimate">
+              <h4>Commander Ultimate</h4>
+              <div class="ultimate-container">
+                <div id="commander-ultimate-img" class="ultimate-image-container">
+                  <span class="no-ultimate">Assign a commander to view ultimate</span>
+                </div>
+                <div id="commander-ultimate-info" class="ultimate-info">
+                  <div class="ultimate-name">-</div>
+                  <div class="ultimate-description">Ultimate triggers when team chakra reaches 16</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div class="team-actions">
         <button class="btn-darkgold" id="btn-save-team">Save Team</button>
         <button class="btn-dark" id="btn-clear-team">Clear All</button>


### PR DESCRIPTION
Implements an off-field commander system that provides:
- Passive team buffs based on element type and star rating
- Ultimate attack support when team chakra reaches 16
- Element-specific buff scaling (Body: ATK, Bravery/Wisdom: ATK+HP, Heart: ATK, Skill: Speed)
- Linear buff scaling from 5★ (baseline) to 10★ (20% max)

Changes:
- teams.html: Added commander slot UI with buff/ultimate displays
- teams.css: Added commander section styling with element-specific colors
- team_manager.js: Implemented buff calculation and ultimate data extraction
- COMMANDER_SYSTEM.md: Added documentation for the commander system

Note: Requires 'element' field in characters.json (to be added via data scraper) Ultimate PNG images to be added separately