### PR TITLE
Implement commander system battle integration

### DIFF
--- a/COMMANDER_SYSTEM.md
+++ b/COMMANDER_SYSTEM.md
@@ -76,12 +76,49 @@ Commander data is stored in localStorage under `blazing_teams_v1`:
 ```
 
 ## Files Modified
+
+### Team Setup
 - `/home/user/Naruto-Blazing/teams.html` - Added commander UI section
 - `/home/user/Naruto-Blazing/css/teams.css` - Added commander styling
 - `/home/user/Naruto-Blazing/js/team_manager.js` - Added commander logic
 
+### Battle Integration
+- `/home/user/Naruto-Blazing/battle.html` - Added collective chakra display in HUD
+- `/home/user/Naruto-Blazing/css/battle.css` - Added commander HUD styling
+- `/home/user/Naruto-Blazing/js/battle/battle-core.js` - Implemented commander loading, buff application, and ultimate trigger
+- `/home/user/Naruto-Blazing/js/battle/battle-turns.js` - Added collective chakra tracking hook
+
+## Battle Implementation
+
+### How It Works in Battle
+
+1. **Battle Start**: Commander is loaded from team data, buffs are calculated and applied to all active team members
+2. **Buff Application**: Passive buffs are permanently applied to unit stats (ATK, HP, Speed)
+3. **Chakra Tracking**: After each turn, collective chakra is calculated (sum of all 4 active units' chakra)
+4. **Ultimate Trigger**: When collective chakra reaches 16+, commander ultimate automatically triggers once per battle
+5. **Ultimate Effects**: Applies damage and buff/debuff effects from character's ultimate skill data
+
+### Battle HUD Display
+
+The battle HUD shows:
+- Commander name
+- Collective chakra value (turns red and pulses when ≥16)
+- Threshold indicator (X/16)
+
+## Existing Systems
+
+### ✅ Character Abilities (WORKING)
+File: `js/battle/battle-passives.js`
+- Passive abilities from characters.json are automatically applied
+- Examples: HP bonuses, conditional ATK, turn-based regen, damage reduction
+
+### ✅ Buffs/Debuffs (WORKING)
+File: `js/battle/battle-buffs.js`
+- Full buff/debuff system with 20+ status effects
+- Debuff cleansing, timed effects, instant heals/revives
+
 ## Future Work
-1. Add ultimate PNG images for each character
-2. Implement ultimate trigger system in battle
-3. Apply passive buffs to team stats in battle
-4. Visual effects for ultimate activation
+1. Add ultimate PNG images for each character (container ready)
+2. Enhanced visual effects for commander ultimate activation
+3. Sound effects for ultimate trigger
+4. Commander-specific animations

--- a/battle.html
+++ b/battle.html
@@ -83,6 +83,17 @@
       </div>
       <span id="team-hp-text" class="hp-text">0 / 0</span>
     </div>
+    <div class="hud-center">
+      <div id="commander-display" class="commander-display hidden">
+        <span class="commander-label">Commander</span>
+        <span id="commander-name" class="commander-name">-</span>
+        <div class="collective-chakra">
+          <span class="chakra-label">Collective Chakra:</span>
+          <span id="collective-chakra-text" class="chakra-value">0</span>
+          <span class="chakra-threshold">/16</span>
+        </div>
+      </div>
+    </div>
     <div class="hud-right">
       <span id="mission-title">Mission</span>
       <span class="wave">Wave <span id="wave-current">1</span>/<span id="wave-total">1</span></span>

--- a/css/battle.css
+++ b/css/battle.css
@@ -93,6 +93,74 @@ html, body.page-battle {
   font-weight: 600;
 }
 
+/* === Commander Display === */
+.hud-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.commander-display {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 2px 8px;
+  background: rgba(20, 20, 30, 0.6);
+  border: 1px solid rgba(217, 179, 98, 0.3);
+  border-radius: 4px;
+}
+
+.commander-display.hidden {
+  display: none;
+}
+
+.commander-label {
+  font-size: 7px;
+  color: #d9b362;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.commander-name {
+  font-size: 8px;
+  color: #fff;
+  font-weight: 600;
+}
+
+.collective-chakra {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 8px;
+}
+
+.chakra-label {
+  color: #c5b894;
+}
+
+.chakra-value {
+  font-weight: 700;
+  color: #4a9eff;
+  min-width: 12px;
+  text-align: center;
+}
+
+.chakra-value.ready {
+  color: #ff4444;
+  animation: pulse-glow 1s ease-in-out infinite;
+}
+
+.chakra-threshold {
+  color: #888;
+}
+
+@keyframes pulse-glow {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
 /* === SPEED GAUGE TRACK === */
 #speed-gauge-track {
   position: absolute;

--- a/js/battle/battle-turns.js
+++ b/js/battle/battle-turns.js
@@ -270,6 +270,11 @@
       if (core.overlay) core.overlay.clear();
       this.clearEnemyHighlights(core);
 
+      // Update collective chakra and check for commander ultimate
+      if (core.updateCollectiveChakra) {
+        core.updateCollectiveChakra();
+      }
+
       // Unlock turn system
       this.turnLocked = false;
       this.currentUnit = null;


### PR DESCRIPTION
Integrates the commander system into battle with full functionality:

Battle Features:
- Loads commander from team data at battle start
- Calculates and applies passive buffs to all active team members
- Tracks collective chakra (sum of all 4 units)
- Automatically triggers commander ultimate at 16+ collective chakra
- Applies ultimate damage and effects to enemies
- One-time ultimate per battle

Buff Application:
- Body: +4-20% ATK (scales with stars)
- Bravery: +3-20% ATK, +1-13.3% HP
- Wisdom: +3-20% ATK, +1-13.3% HP
- Heart: +4-20% ATK
- Skill: +4-20% Speed

UI Enhancements:
- Added commander display in battle HUD
- Shows commander name and collective chakra
- Red pulsing indicator when ultimate ready (≥16 chakra)

Technical Changes:
- battle-core.js: Commander loading, buff calculation/application, ultimate trigger
- battle-turns.js: Collective chakra tracking hook at turn end
- battle.html: Commander HUD display element
- battle.css: Commander HUD styling with pulse animation
- COMMANDER_SYSTEM.md: Updated documentation with battle implementation

Note: Character abilities and debuffs already working via battle-passives.js and battle-buffs.js