### PR TITLE
Fix critical JavaScript error blocking gift code system

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -348,14 +348,18 @@
     const muteButton = document.getElementById('mute-button');
 
     // Load current audio settings
-    if (typeof AudioManager !== 'undefined') {
-      const settings = AudioManager.getSettings();
-      bgmSlider.value = Math.round(settings.bgmVolume * 100);
-      bgmValue.textContent = Math.round(settings.bgmVolume * 100) + '%';
-      sfxSlider.value = Math.round(settings.sfxVolume * 100);
-      sfxValue.textContent = Math.round(settings.sfxVolume * 100) + '%';
-      muteButton.textContent = settings.masterMuted ? 'Muted' : 'Unmuted';
-      muteButton.classList.toggle('active', !settings.masterMuted);
+    if (typeof AudioManager !== 'undefined' && typeof AudioManager.getSettings === 'function') {
+      try {
+        const settings = AudioManager.getSettings();
+        bgmSlider.value = Math.round(settings.bgmVolume * 100);
+        bgmValue.textContent = Math.round(settings.bgmVolume * 100) + '%';
+        sfxSlider.value = Math.round(settings.sfxVolume * 100);
+        sfxValue.textContent = Math.round(settings.sfxVolume * 100) + '%';
+        muteButton.textContent = settings.masterMuted ? 'Muted' : 'Unmuted';
+        muteButton.classList.toggle('active', !settings.masterMuted);
+      } catch (error) {
+        console.warn('[Settings] Could not load audio settings:', error);
+      }
     }
 
     // BGM Volume Control


### PR DESCRIPTION
Issue: AudioManager.getSettings() doesn't exist, causing uncaught TypeError This error stopped all subsequent JavaScript from executing, preventing:
- Gift Code System initialization
- Manual unit addition functionality

Fix: Add function existence check and try-catch wrapper Now gift code system will initialize properly even if audio settings fail.

Error was: settings.html:352 Uncaught TypeError: AudioManager.getSettings is not a function