### PR TITLE
Add awakening character transform system

### DIFF
--- a/data/awakening-transforms.json
+++ b/data/awakening-transforms.json
@@ -1,0 +1,15 @@
+{
+  "transforms": {
+    "naruto_665": {
+      "6SB": "naruto_666"
+    },
+    "naruto_659": {
+      "6S": "naruto_660"
+    }
+  },
+  "notes": {
+    "description": "Character ID transforms that occur during awakening",
+    "usage": "When a character awakens to a specific tier, check if it should transform into a different character ID",
+    "format": "characterId: { tierCode: newCharacterId }"
+  }
+}


### PR DESCRIPTION
Implements automatic character ID transformation during awakening to handle cases where awakening to a specific tier should change the character ID (e.g., naruto_665 → naruto_666 at 6SB tier).

Changes:
- Created data/awakening-transforms.json to map character transforms
  - naruto_665 transforms to naruto_666 at tier 6SB
  - naruto_659 transforms to naruto_660 at tier 6S
- Modified js/awakening.js to:
  - Load and cache transform mappings
  - Apply character ID transform after tier promotion
  - Show correct artwork and stats in awakening preview
  - Update inventory after transform

Fixes issue where naruto_665 awakening to 6SB showed wrong/missing artwork because the 6SB art belongs to naruto_666 character folder.