### PR TITLE
Fix Naruto 659 awakening to enable transformation to 660

### DIFF
--- a/data/characters.json
+++ b/data/characters.json
@@ -69642,7 +69642,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": true,
     "portrait": "assets/characters/naruto_659/portrait_5S.png",
     "full": "assets/characters/naruto_659/full_5S.png",


### PR DESCRIPTION
Changed naruto_659's starMaxCode from "5S" to "6S" to allow awakening beyond 5-star. This enables the character to awaken to 6S tier, which triggers the transformation to naruto_660 as configured in awakening-transforms.json.

The transformation was already configured correctly, but the character's max tier restriction was preventing the awakening button from becoming active.