### PR TITLE
Fix awakening system, remove scrollbar, and sort character inventory

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -306,29 +306,25 @@ body.page-characters::-webkit-scrollbar {
   min-height: 450px; /* Ensure consistent minimum height */
   max-height: 450px; /* Lock maximum height */
   overflow-y: auto;  /* Enable scrolling for overflow content */
+  scrollbar-width: none; /* Firefox - hide scrollbar */
+  -ms-overflow-style: none; /* IE and Edge - hide scrollbar */
+}
+/* Hide scrollbar for Chrome, Safari and Opera */
+.tab-panels::-webkit-scrollbar {
+  display: none;
 }
 .tab-panel {
   display: none;
   min-height: 420px; /* All tabs have same minimum height */
   overflow-y: auto;  /* Individual tab scrolling */
+  scrollbar-width: none; /* Firefox - hide scrollbar */
+  -ms-overflow-style: none; /* IE and Edge - hide scrollbar */
+}
+/* Hide scrollbar for Chrome, Safari and Opera */
+.tab-panel::-webkit-scrollbar {
+  display: none;
 }
 .tab-panel.is-active { display: block; }
-
-/* Custom scrollbar for tab panels */
-.tab-panel::-webkit-scrollbar {
-  width: 6px;
-}
-.tab-panel::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, 0.2);
-  border-radius: 4px;
-}
-.tab-panel::-webkit-scrollbar-thumb {
-  background: rgba(217, 179, 98, 0.4);
-  border-radius: 4px;
-}
-.tab-panel::-webkit-scrollbar-thumb:hover {
-  background: rgba(217, 179, 98, 0.6);
-}
 
 /* ---------- Stats Grid ---------- */
 .stats-grid {
@@ -353,6 +349,12 @@ body.page-characters::-webkit-scrollbar {
 .growth-ops {
   max-height: 320px;  /* Prevent overflow in status tab */
   overflow-y: auto;   /* Allow scrolling if needed */
+  scrollbar-width: none; /* Firefox - hide scrollbar */
+  -ms-overflow-style: none; /* IE and Edge - hide scrollbar */
+}
+/* Hide scrollbar for Chrome, Safari and Opera */
+.growth-ops::-webkit-scrollbar {
+  display: none;
 }
 .level-strip {
   display: flex;
@@ -662,6 +664,12 @@ body.page-characters::-webkit-scrollbar {
   max-height: 450px;                    /* lock maximum height */
   overflow-y: auto;                     /* scroll inside the right side only */
   padding: 14px 20px 8px;
+  scrollbar-width: none;                /* Firefox - hide scrollbar */
+  -ms-overflow-style: none;             /* IE and Edge - hide scrollbar */
+}
+/* Hide scrollbar for Chrome, Safari and Opera */
+.tab-panels::-webkit-scrollbar {
+  display: none;
 }
 .char-modal-actions{
   margin-top: 8px;

--- a/js/characters.js
+++ b/js/characters.js
@@ -192,7 +192,24 @@
       return;
     }
 
-    GRID.innerHTML = instances.map(inst => {
+    // Sort characters by star rating (highest to lowest)
+    const sortedInstances = instances.sort((a, b) => {
+      const charA = BYID[a.charId];
+      const charB = BYID[b.charId];
+
+      // Get tier codes
+      const tierA = a.tierCode || (charA ? minTier(charA) : "3S");
+      const tierB = b.tierCode || (charB ? minTier(charB) : "3S");
+
+      // Get star counts from tier codes
+      const starsA = starsFromTier(tierA);
+      const starsB = starsFromTier(tierB);
+
+      // Sort by stars descending (highest first)
+      return starsB - starsA;
+    });
+
+    GRID.innerHTML = sortedInstances.map(inst => {
       const c = BYID[inst.charId];
       if (!c) {
         return `

--- a/js/progression.js
+++ b/js/progression.js
@@ -11,12 +11,12 @@
    * ============================= */
   // Order from lowest to highest
   const TIER_ORDER = [
-    "3S","4S","5S","6S","6SB","7S","7SL","8S","8SM","9S","9ST","10SO"
+    "1S","2S","3S","4S","5S","6S","6SB","7S","7SL","8S","8SM","9S","9ST","10SO"
   ];
 
   // Default level caps per tier (tune as you like)
   const TIER_CAPS = {
-    "3S": 40, "4S": 55, "5S": 70,
+    "1S": 20, "2S": 30, "3S": 40, "4S": 55, "5S": 70,
     "6S": 100, "6SB": 100,
     "7S": 100, "7SL": 100,
     "8S": 110, "8SM": 120,
@@ -27,7 +27,7 @@
   // Baseline progress (0..1) across the TOTAL spectrum (absolute),
   // used to derive a relative fraction between a character's min↔max bands.
   const TIER_PROGRESS_ABS = {
-    "3S": 0.10, "4S": 0.25, "5S": 0.45,
+    "1S": 0.03, "2S": 0.06, "3S": 0.10, "4S": 0.25, "5S": 0.45,
     "6S": 0.70, "6SB": 0.76,
     "7S": 0.82, "7SL": 0.87,
     "8S": 0.91, "8SM": 0.94,


### PR DESCRIPTION
1. Add 1S and 2S tier codes to progression system
   - Fixed awakening for characters 659->660 and 661->662
   - Added proper tier caps and progress values for 1S and 2S tiers

2. Remove scrollbar from character modal
   - Hidden scrollbar in .tab-panels and .tab-panel
   - Hidden scrollbar in .growth-ops section
   - Maintained scroll functionality while hiding visual scrollbar

3. Sort character inventory by star rating
   - Characters now display highest stars first, lowest last
   - Sorting applied in renderGrid() function