### PR TITLE
Fix GitHub Actions permissions for deployment workflows

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   deploy-production:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy-staging:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/validate-content.yml
+++ b/.github/workflows/validate-content.yml
@@ -13,6 +13,10 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Add required permissions blocks to all workflows to fix "Resource not accessible by integration" error:
- validate-content.yml: Add issues/PR write permissions for commenting
- deploy-staging.yml: Add contents write permission for commit comments
- deploy-production.yml: Add contents write permission for creating releases and tags

This resolves the 403 error preventing deployments.