### PR TITLE
Fix awakening character transformation to update artwork and characte…

### DIFF
--- a/js/characters.js
+++ b/js/characters.js
@@ -981,8 +981,27 @@
         return;
       }
 
-      if (!res.persisted && res.tier) {
-        window.InventoryChar.updateInstance(inst.uid, { tierCode: res.tier, level: res.level ?? 1 });
+      // Check if character transformed to a new ID
+      if (res.transformed && res.newCharacterId) {
+        // Update instance with new character ID, tier, and level
+        window.InventoryChar.updateInstance(inst.uid, {
+          characterId: res.newCharacterId,
+          tierCode: res.tier,
+          level: res.level ?? 1
+        });
+
+        // Reload the new character data
+        const newCharacter = await window.Characters.getCharacterById(res.newCharacterId);
+        if (newCharacter) {
+          // Update all references to use the new character
+          c = newCharacter;
+          inst = window.InventoryChar.getByUid(inst.uid);
+        }
+      } else {
+        // Standard awakening without transformation
+        if (!res.persisted && res.tier) {
+          window.InventoryChar.updateInstance(inst.uid, { tierCode: res.tier, level: res.level ?? 1 });
+        }
       }
 
       const fresh = window.InventoryChar.getByUid(inst.uid);
@@ -991,6 +1010,12 @@
       const art = resolveTierArt(c, newTier);
       MODAL_IMG.src = safeStr(art.full, art.portrait);
       NP_STARS.innerHTML = renderStars(starsFromTier(newTier));
+
+      // Update nameplate with new character name/version if transformed
+      if (res.transformed && c) {
+        NP_NAME.textContent = c.name || "";
+        NP_VERSION.textContent = c.version || "";
+      }
 
       await window.renderStatusTab(c, fresh, newTier);
       renderSkillsTab(c, fresh, newTier);


### PR DESCRIPTION
…r data

Problem: When awakening naruto_659, the character was transforming to naruto_660 in the backend (awakening.js), but the UI wasn't updating to show the new character's artwork or data.

Solution:
- Check if performAwaken returned a transformation (res.transformed)
- Update the instance with the new characterId, not just tier/level
- Reload the new character data using Characters.getCharacterById
- Update all UI references (artwork, nameplate) to use new character

Now when naruto_659 awakens to 6S tier, it correctly transforms to naruto_660 with the new portrait and full artwork displayed.

Fixes: Awakening transformation artwork not updating