### PR TITLE
Add comprehensive debugging for Naruto 659→660 awakening transformation

### DIFF
--- a/js/awakening.js
+++ b/js/awakening.js
@@ -27,9 +27,13 @@
 
   // Load awakening transforms from JSON
   async function loadTransforms() {
-    if (_awakeningTransforms) return _awakeningTransforms;
+    if (_awakeningTransforms) {
+      console.log("[Awakening Debug] Using cached transforms");
+      return _awakeningTransforms;
+    }
 
     try {
+      console.log("[Awakening Debug] Loading transforms from JSON...");
       const res = await fetch("data/awakening-transforms.json", { cache: "no-store" });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
@@ -45,6 +49,8 @@
           }
           _awakeningTransforms[transform.fromId][transform.tier] = transform.toId;
         });
+        console.log(`[Awakening Debug] Loaded ${data.length} transform mappings`);
+        console.log("[Awakening Debug] Sample: naruto_659 ->", _awakeningTransforms["naruto_659"]);
       } else {
         _awakeningTransforms = data.transforms || {};
       }
@@ -154,11 +160,18 @@
 
     // Check if character should transform to a different ID at this tier
     const newTier = result.tier;
+    console.log(`[Awakening Debug] Checking transform for ${oldCharacterId} at tier ${newTier}`);
+
     const transformToId = await getTransformForTier(oldCharacterId, newTier);
+    console.log(`[Awakening Debug] Transform result:`, transformToId);
 
     if (transformToId) {
       console.log(`✨ [Awakening Transform] ${oldCharacterId} → ${transformToId} at tier ${newTier}`);
+
+      // Update the instance character ID
       inst.characterId = transformToId;
+
+      // Set transformation flags in result
       result.transformed = true;
       result.oldCharacterId = oldCharacterId;
       result.newCharacterId = transformToId;
@@ -166,7 +179,12 @@
       // Save inventory if available
       if (global.InventoryChar && typeof global.InventoryChar.save === 'function') {
         global.InventoryChar.save();
+        console.log(`✅ [Awakening Transform] Saved inventory with new characterId: ${transformToId}`);
+      } else {
+        console.warn(`⚠️ [Awakening Transform] InventoryChar.save not available`);
       }
+    } else {
+      console.log(`[Awakening Debug] No transformation found for ${oldCharacterId} at tier ${newTier}`);
     }
 
     return result;

--- a/js/characters.js
+++ b/js/characters.js
@@ -982,22 +982,32 @@
       }
 
       // Check if character transformed to a new ID
+      console.log("[UI Debug] Awakening result:", { transformed: res.transformed, newCharacterId: res.newCharacterId, tier: res.tier });
+
       if (res.transformed && res.newCharacterId) {
+        console.log(`[UI Debug] Character transformed from ${inst.characterId} to ${res.newCharacterId}`);
+
         // Update instance with new character ID, tier, and level
         window.InventoryChar.updateInstance(inst.uid, {
           characterId: res.newCharacterId,
           tierCode: res.tier,
           level: res.level ?? 1
         });
+        console.log("[UI Debug] Instance updated with new character ID");
 
         // Reload the new character data
         const newCharacter = await window.Characters.getCharacterById(res.newCharacterId);
         if (newCharacter) {
+          console.log(`[UI Debug] Loaded new character: ${newCharacter.name} (${newCharacter.id})`);
           // Update all references to use the new character
           c = newCharacter;
           inst = window.InventoryChar.getByUid(inst.uid);
+          console.log("[UI Debug] Updated local references to new character");
+        } else {
+          console.error("[UI Debug] Failed to load new character:", res.newCharacterId);
         }
       } else {
+        console.log("[UI Debug] Standard awakening without transformation");
         // Standard awakening without transformation
         if (!res.persisted && res.tier) {
           window.InventoryChar.updateInstance(inst.uid, { tierCode: res.tier, level: res.level ?? 1 });


### PR DESCRIPTION
Added detailed console logging throughout the awakening transformation process:

In awakening.js:
- Log when checking for transforms (character ID + tier)
- Log transform lookup results
- Log successful transformations with old→new character IDs
- Log inventory save status
- Log when no transformation is found

In characters.js:
- Log awakening result details (transformed flag, new character ID, tier)
- Log transformation detection
- Log instance updates
- Log character data loading success/failure
- Log reference updates

This will help diagnose why naruto_659 may not be transforming to naruto_660 when awakened to tier 6S.

Issue: Naruto 659 should transform to Naruto 660 when awakened to 6S tier