### PR TITLE
CRITICAL FIX: Old character shows first + Circular frame

### DIFF
--- a/css/awakening-animation.css
+++ b/css/awakening-animation.css
@@ -32,21 +32,32 @@
   justify-content: center;
 }
 
-/* Character image container - center of everything */
+/* Character image container - CIRCULAR FRAME */
 .awakening-character {
   position: absolute;
-  width: 400px;
-  height: 550px;
+  width: 450px;
+  height: 450px;
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 2;
+
+  /* Circular frame styling */
+  border-radius: 50%;
+  overflow: hidden;
+  border: 5px solid #ffd700;
+  box-shadow:
+    0 0 30px rgba(255, 215, 0, 0.8),
+    0 0 60px rgba(255, 215, 0, 0.5),
+    inset 0 0 40px rgba(255, 215, 0, 0.3);
+  background: radial-gradient(circle, rgba(20, 20, 30, 0.9) 0%, rgba(0, 0, 0, 0.95) 100%);
 }
 
 .awakening-character img {
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
   animation: characterBlurReveal 5s ease-in-out forwards;
 }
 
@@ -402,8 +413,8 @@
   }
 
   .awakening-character {
-    width: 300px;
-    height: 400px;
+    width: 350px;
+    height: 350px;
   }
 
   .awakening-kanji {

--- a/js/characters.js
+++ b/js/characters.js
@@ -1013,7 +1013,15 @@
       if (res.transformed && res.newCharacterId) {
         console.log(`[UI Debug] Character transformed from ${inst.charId} to ${res.newCharacterId}`);
 
-        // Update instance with new character ID, tier, and level
+        // *** GET OLD CHARACTER DATA BEFORE UPDATING ANYTHING ***
+        const oldCharacterName = c.name;
+        const oldTier = inst.tierCode || maxTier(c);
+        const oldArt = resolveTierArt(c, oldTier);
+        const oldArtworkUrl = safeStr(oldArt.full, oldArt.portrait);
+        console.log(`[UI Debug] Saved old character data: ${oldCharacterName} at tier ${oldTier}`);
+        console.log(`[UI Debug] Old artwork URL: ${oldArtworkUrl}`);
+
+        // Now update instance with new character ID, tier, and level
         // IMPORTANT: Use 'charId' not 'characterId' - that's the correct property name in inventory
         window.InventoryChar.updateInstance(inst.uid, {
           charId: res.newCharacterId,
@@ -1027,15 +1035,10 @@
         if (newCharacter) {
           console.log(`[UI Debug] Loaded new character: ${newCharacter.name} (${newCharacter.id})`);
 
-          // Get old character data for animation (before updating c)
-          const oldCharacterName = c.name;
-          const oldTier = inst.tierCode || maxTier(c);
-          const oldArt = resolveTierArt(c, oldTier);
-          const oldArtworkUrl = safeStr(oldArt.full, oldArt.portrait);
-
           // Calculate new character artwork
           const newArt = resolveTierArt(newCharacter, res.tier);
           const newArtworkUrl = safeStr(newArt.full, newArt.portrait);
+          console.log(`[UI Debug] New artwork URL: ${newArtworkUrl}`);
 
           // Update all references to use the new character
           c = newCharacter;


### PR DESCRIPTION
1. GET OLD ARTWORK BEFORE UPDATING INSTANCE
   - Moved old artwork URL capture BEFORE updateInstance call
   - This ensures animation shows OLD character first, not new
   - Added debug logging for old/new artwork URLs

2. CIRCULAR FRAME FOR CHARACTER IMAGE
   - Changed container from 400x550 rect to 450x450 circle
   - Added border-radius: 50% + overflow: hidden
   - Golden glowing border with box-shadow effects
   - Image now uses object-fit: cover to fill circle properly
   - Dark gradient background behind character
   - Mobile: 350x350 circle

Animation sequence now correct:
- Old character appears in circle
- Kanji orbit and glow
- Character blurs
- Flash effect
- New character revealed in circle