### PR TITLE
Hide scrollbars across all pages (keep scroll functionality)

### DIFF
--- a/battle.html
+++ b/battle.html
@@ -76,6 +76,21 @@
       object-fit: cover !important;
     }
   </style>
+  <!-- Hide scrollbar but keep functionality -->
+  <style>
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    body::-webkit-scrollbar,
+    html::-webkit-scrollbar,
+    *::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    body, html, * {
+      -ms-overflow-style: none;  /* IE and Edge */
+      scrollbar-width: none;  /* Firefox */
+    }
+  </style>
 </head>
 <body class="page-battle">
   <!-- 16:9 Game Canvas Wrapper -->

--- a/chakra-holder-demo.html
+++ b/chakra-holder-demo.html
@@ -5,6 +5,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chakra Holder System</title>
     <link rel="stylesheet" href="css/chakra-holder.css">
+  <!-- Hide scrollbar but keep functionality -->
+  <style>
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    body::-webkit-scrollbar,
+    html::-webkit-scrollbar,
+    *::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    body, html, * {
+      -ms-overflow-style: none;  /* IE and Edge */
+      scrollbar-width: none;  /* Firefox */
+    }
+  </style>
 </head>
 <body>
     <div class="unit-slot" id="unit1">

--- a/characters.html
+++ b/characters.html
@@ -14,6 +14,21 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@700&display=swap" rel="stylesheet">
+  <!-- Hide scrollbar but keep functionality -->
+  <style>
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    body::-webkit-scrollbar,
+    html::-webkit-scrollbar,
+    *::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    body, html, * {
+      -ms-overflow-style: none;  /* IE and Edge */
+      scrollbar-width: none;  /* Firefox */
+    }
+  </style>
 </head>
 <body class="page-characters">
   <div id="char-bg"></div>

--- a/fusion.html
+++ b/fusion.html
@@ -7,6 +7,21 @@
   <link rel="stylesheet" href="css/fusion.css" />
   <link rel="stylesheet" href="css/background.css" />
   <link rel="stylesheet" href="css/settings-modal.css" />
+  <!-- Hide scrollbar but keep functionality -->
+  <style>
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    body::-webkit-scrollbar,
+    html::-webkit-scrollbar,
+    *::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    body, html, * {
+      -ms-overflow-style: none;  /* IE and Edge */
+      scrollbar-width: none;  /* Firefox */
+    }
+  </style>
 </head>
 <body class="page-fusion">
   <div id="fusion-bg"></div>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,21 @@
   <link rel="stylesheet" href="css/ui-layout.css?v=2" />
   <link rel="stylesheet" href="css/settings-modal.css?v=2" />
   <link rel="stylesheet" href="css/modal-system.css?v=1" />
+  <!-- Hide scrollbar but keep functionality -->
+  <style>
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    body::-webkit-scrollbar,
+    html::-webkit-scrollbar,
+    *::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    body, html, * {
+      -ms-overflow-style: none;  /* IE and Edge */
+      scrollbar-width: none;  /* Firefox */
+    }
+  </style>
 </head>
 
 <body>

--- a/inventory.html
+++ b/inventory.html
@@ -7,6 +7,21 @@
   <link rel="stylesheet" href="css/inventory.css">
   <link rel="stylesheet" href="css/background.css">
   <link rel="stylesheet" href="css/music-player.css" />
+  <!-- Hide scrollbar but keep functionality -->
+  <style>
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    body::-webkit-scrollbar,
+    html::-webkit-scrollbar,
+    *::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    body, html, * {
+      -ms-overflow-style: none;  /* IE and Edge */
+      scrollbar-width: none;  /* Firefox */
+    }
+  </style>
 </head>
 <body>
   <div id="full-bg" aria-hidden="true"></div>

--- a/missions.html
+++ b/missions.html
@@ -7,6 +7,21 @@
   <link rel="stylesheet" href="css/missions.css">
   <link rel="stylesheet" href="css/background.css">
   <link rel="stylesheet" href="css/settings-modal.css" />
+  <!-- Hide scrollbar but keep functionality -->
+  <style>
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    body::-webkit-scrollbar,
+    html::-webkit-scrollbar,
+    *::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    body, html, * {
+      -ms-overflow-style: none;  /* IE and Edge */
+      scrollbar-width: none;  /* Firefox */
+    }
+  </style>
 </head>
 <body>
   <div id="full-bg" aria-hidden="true"></div>

--- a/resources.html
+++ b/resources.html
@@ -153,6 +153,21 @@
       transform: translateY(-1px);
     }
   </style>
+  <!-- Hide scrollbar but keep functionality -->
+  <style>
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    body::-webkit-scrollbar,
+    html::-webkit-scrollbar,
+    *::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    body, html, * {
+      -ms-overflow-style: none;  /* IE and Edge */
+      scrollbar-width: none;  /* Firefox */
+    }
+  </style>
 </head>
 <body class="page-resources">
   <main class="resources-content">

--- a/settings.html
+++ b/settings.html
@@ -157,6 +157,21 @@
       box-shadow: 0 4px 8px rgba(178, 44, 44, 0.7);
     }
   </style>
+  <!-- Hide scrollbar but keep functionality -->
+  <style>
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    body::-webkit-scrollbar,
+    html::-webkit-scrollbar,
+    *::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    body, html, * {
+      -ms-overflow-style: none;  /* IE and Edge */
+      scrollbar-width: none;  /* Firefox */
+    }
+  </style>
 </head>
 
 <body>

--- a/shop.html
+++ b/shop.html
@@ -7,6 +7,21 @@
   <link rel="stylesheet" href="css/shop.css" />
   <link rel="stylesheet" href="css/background.css" />
   <link rel="stylesheet" href="css/music-player.css" />
+  <!-- Hide scrollbar but keep functionality -->
+  <style>
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    body::-webkit-scrollbar,
+    html::-webkit-scrollbar,
+    *::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    body, html, * {
+      -ms-overflow-style: none;  /* IE and Edge */
+      scrollbar-width: none;  /* Firefox */
+    }
+  </style>
 </head>
 <body class="page-shop">
   <div id="shop-bg"></div>

--- a/summon.html
+++ b/summon.html
@@ -13,6 +13,21 @@
   <link rel="stylesheet" href="css/summon-banner-carousel.css" />
   <link rel="stylesheet" href="css/summon-results.css" />
   <link rel="stylesheet" href="css/settings-modal.css" />
+  <!-- Hide scrollbar but keep functionality -->
+  <style>
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    body::-webkit-scrollbar,
+    html::-webkit-scrollbar,
+    *::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    body, html, * {
+      -ms-overflow-style: none;  /* IE and Edge */
+      scrollbar-width: none;  /* Firefox */
+    }
+  </style>
 </head>
 <body class="page-summon">
   <!-- 16:9 Game Canvas Wrapper -->

--- a/teams.html
+++ b/teams.html
@@ -8,6 +8,21 @@
   <link rel="stylesheet" href="css/background.css" />
   <link rel="stylesheet" href="css/status_effects.css" />
   <link rel="stylesheet" href="css/settings-modal.css" />
+  <!-- Hide scrollbar but keep functionality -->
+  <style>
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    body::-webkit-scrollbar,
+    html::-webkit-scrollbar,
+    *::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    body, html, * {
+      -ms-overflow-style: none;  /* IE and Edge */
+      scrollbar-width: none;  /* Firefox */
+    }
+  </style>
 </head>
 <body class="page-teams">
   <div id="team-bg"></div>

--- a/test-bench-chakra.html
+++ b/test-bench-chakra.html
@@ -37,6 +37,21 @@
       border-radius: 4px;
     }
   </style>
+  <!-- Hide scrollbar but keep functionality -->
+  <style>
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    body::-webkit-scrollbar,
+    html::-webkit-scrollbar,
+    *::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    body, html, * {
+      -ms-overflow-style: none;  /* IE and Edge */
+      scrollbar-width: none;  /* Firefox */
+    }
+  </style>
 </head>
 <body>
   <div class="test-container">


### PR DESCRIPTION
Added scrollbar hiding CSS to all HTML pages:
- index.html
- characters.html
- battle.html
- fusion.html
- inventory.html
- missions.html
- resources.html
- settings.html
- shop.html
- summon.html
- teams.html
- chakra-holder-demo.html
- test-bench-chakra.html
- HTML_UPDATE_SNIPPET.html

CSS hides scrollbars for:
- Chrome, Safari, Opera (using ::-webkit-scrollbar)
- Firefox (using scrollbar-width: none)
- IE, Edge (using -ms-overflow-style: none)

Scrolling functionality is fully preserved - only the visual scrollbar is hidden.