### PR TITLE
Fix character awakening by correcting starMaxCode values

### DIFF
--- a/data/characters.json
+++ b/data/characters.json
@@ -37,11 +37,11 @@
       "speed": 108
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2642,
     "powerWeights": {
@@ -138,11 +138,11 @@
       "speed": 144
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3885,
     "powerWeights": {
@@ -243,11 +243,11 @@
       "speed": 180
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5951,
     "powerWeights": {
@@ -329,7 +329,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_004/portrait_3S.png",
     "full": "assets/characters/sasuke_004/full_3S.png",
@@ -356,11 +356,11 @@
       "speed": 105
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3248,
     "powerWeights": {
@@ -457,11 +457,11 @@
       "speed": 131
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4960,
     "powerWeights": {
@@ -539,7 +539,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/sakura_006/portrait_3S.png",
     "full": "assets/characters/sakura_006/full_3S.png",
@@ -566,11 +566,11 @@
       "speed": 233
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 1502,
     "powerWeights": {
@@ -663,11 +663,11 @@
       "speed": 291
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2719,
     "powerWeights": {
@@ -741,7 +741,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/kakashi_008/portrait_4S.png",
     "full": "assets/characters/kakashi_008/full_4S.png",
@@ -768,11 +768,11 @@
       "speed": 97
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5051,
     "powerWeights": {
@@ -870,11 +870,11 @@
       "speed": 121
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6956,
     "powerWeights": {
@@ -953,7 +953,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/shikamaru_010/portrait_3S.png",
     "full": "assets/characters/shikamaru_010/full_3S.png",
@@ -980,11 +980,11 @@
       "speed": 214
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 1530,
     "powerWeights": {
@@ -1077,11 +1077,11 @@
       "speed": 267
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2748,
     "powerWeights": {
@@ -1155,7 +1155,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/ino_012/portrait_3S.png",
     "full": "assets/characters/ino_012/full_3S.png",
@@ -1182,11 +1182,11 @@
       "speed": 211
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2365,
     "powerWeights": {
@@ -1279,11 +1279,11 @@
       "speed": 264
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3512,
     "powerWeights": {
@@ -1357,7 +1357,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/choji_014/portrait_3S.png",
     "full": "assets/characters/choji_014/full_3S.png",
@@ -1384,11 +1384,11 @@
       "speed": 128
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3588,
     "powerWeights": {
@@ -1481,11 +1481,11 @@
       "speed": 160
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5671,
     "powerWeights": {
@@ -1559,7 +1559,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/hinata_016/portrait_3S.png",
     "full": "assets/characters/hinata_016/full_3S.png",
@@ -1586,11 +1586,11 @@
       "speed": 81
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3321,
     "powerWeights": {
@@ -1683,11 +1683,11 @@
       "speed": 101
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5038,
     "powerWeights": {
@@ -1761,7 +1761,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/kiba_018/portrait_3S.png",
     "full": "assets/characters/kiba_018/full_3S.png",
@@ -1788,11 +1788,11 @@
       "speed": 202
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2109,
     "powerWeights": {
@@ -1885,11 +1885,11 @@
       "speed": 253
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3337,
     "powerWeights": {
@@ -1963,7 +1963,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/shino_020/portrait_3S.png",
     "full": "assets/characters/shino_020/full_3S.png",
@@ -1990,11 +1990,11 @@
       "speed": 226
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 1402,
     "powerWeights": {
@@ -2087,11 +2087,11 @@
       "speed": 283
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2460,
     "powerWeights": {
@@ -2165,7 +2165,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/iruka_022/portrait_3S.png",
     "full": "assets/characters/iruka_022/full_3S.png",
@@ -2192,11 +2192,11 @@
       "speed": 220
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2183,
     "powerWeights": {
@@ -2289,11 +2289,11 @@
       "speed": 275
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3582,
     "powerWeights": {
@@ -2390,11 +2390,11 @@
       "speed": 146
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3266,
     "powerWeights": {
@@ -2487,11 +2487,11 @@
       "speed": 145
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3167,
     "powerWeights": {
@@ -2584,11 +2584,11 @@
       "speed": 255
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2138,
     "powerWeights": {
@@ -2681,11 +2681,11 @@
       "speed": 247
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2009,
     "powerWeights": {
@@ -2778,11 +2778,11 @@
       "speed": 145
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3216,
     "powerWeights": {
@@ -2875,11 +2875,11 @@
       "speed": 336
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 1672,
     "powerWeights": {
@@ -2972,11 +2972,11 @@
       "speed": 144
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3145,
     "powerWeights": {
@@ -3069,11 +3069,11 @@
       "speed": 166
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3297,
     "powerWeights": {
@@ -3167,11 +3167,11 @@
       "speed": 95
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3237,
     "powerWeights": {
@@ -3265,11 +3265,11 @@
       "speed": 238
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2410,
     "powerWeights": {
@@ -3362,11 +3362,11 @@
       "speed": 248
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2003,
     "powerWeights": {
@@ -3459,11 +3459,11 @@
       "speed": 299
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 1383,
     "powerWeights": {
@@ -3556,11 +3556,11 @@
       "speed": 252
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2087,
     "powerWeights": {
@@ -3653,11 +3653,11 @@
       "speed": 293
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 1527,
     "powerWeights": {
@@ -3750,11 +3750,11 @@
       "speed": 144
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3117,
     "powerWeights": {
@@ -3847,11 +3847,11 @@
       "speed": 314
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 1456,
     "powerWeights": {
@@ -3944,11 +3944,11 @@
       "speed": 146
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3282,
     "powerWeights": {
@@ -4041,11 +4041,11 @@
       "speed": 145
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3167,
     "powerWeights": {
@@ -4138,11 +4138,11 @@
       "speed": 255
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2138,
     "powerWeights": {
@@ -4235,11 +4235,11 @@
       "speed": 247
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 1971,
     "powerWeights": {
@@ -4309,7 +4309,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_044/portrait_5S.png",
     "full": "assets/characters/naruto_044/full_5S.png",
@@ -4336,11 +4336,11 @@
       "speed": 209
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5280,
     "powerWeights": {
@@ -4441,11 +4441,11 @@
       "speed": 262
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6978,
     "powerWeights": {
@@ -4527,7 +4527,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_046/portrait_5S.png",
     "full": "assets/characters/sasuke_046/full_5S.png",
@@ -4554,11 +4554,11 @@
       "speed": 127
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8492,
     "powerWeights": {
@@ -4659,11 +4659,11 @@
       "speed": 159
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10476,
     "powerWeights": {
@@ -4745,7 +4745,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kakashi_048/portrait_5S.png",
     "full": "assets/characters/kakashi_048/full_5S.png",
@@ -4772,11 +4772,11 @@
       "speed": 198
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5561,
     "powerWeights": {
@@ -4877,11 +4877,11 @@
       "speed": 248
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7026,
     "powerWeights": {
@@ -4963,7 +4963,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/gaara_050/portrait_5S.png",
     "full": "assets/characters/gaara_050/full_5S.png",
@@ -4990,11 +4990,11 @@
       "speed": 266
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3889,
     "powerWeights": {
@@ -5096,11 +5096,11 @@
       "speed": 333
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4744,
     "powerWeights": {
@@ -5183,7 +5183,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/sakura_052/portrait_4S.png",
     "full": "assets/characters/sakura_052/full_4S.png",
@@ -5210,11 +5210,11 @@
       "speed": 269
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2947,
     "powerWeights": {
@@ -5311,11 +5311,11 @@
       "speed": 336
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4052,
     "powerWeights": {
@@ -5393,7 +5393,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/shikamaru_054/portrait_4S.png",
     "full": "assets/characters/shikamaru_054/full_4S.png",
@@ -5420,11 +5420,11 @@
       "speed": 213
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3400,
     "powerWeights": {
@@ -5522,11 +5522,11 @@
       "speed": 267
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4597,
     "powerWeights": {
@@ -5605,7 +5605,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/ino_056/portrait_4S.png",
     "full": "assets/characters/ino_056/full_4S.png",
@@ -5632,11 +5632,11 @@
       "speed": 217
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4267,
     "powerWeights": {
@@ -5733,11 +5733,11 @@
       "speed": 271
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5600,
     "powerWeights": {
@@ -5815,7 +5815,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/choji_058/portrait_4S.png",
     "full": "assets/characters/choji_058/full_4S.png",
@@ -5842,11 +5842,11 @@
       "speed": 83
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6101,
     "powerWeights": {
@@ -5943,11 +5943,11 @@
       "speed": 104
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9123,
     "powerWeights": {
@@ -6025,7 +6025,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/hinata_060/portrait_4S.png",
     "full": "assets/characters/hinata_060/full_4S.png",
@@ -6052,11 +6052,11 @@
       "speed": 180
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5619,
     "powerWeights": {
@@ -6154,11 +6154,11 @@
       "speed": 180
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7153,
     "powerWeights": {
@@ -6237,7 +6237,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/kiba_062/portrait_4S.png",
     "full": "assets/characters/kiba_062/full_4S.png",
@@ -6264,11 +6264,11 @@
       "speed": 174
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4099,
     "powerWeights": {
@@ -6365,11 +6365,11 @@
       "speed": 217
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5576,
     "powerWeights": {
@@ -6447,7 +6447,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/shino_064/portrait_4S.png",
     "full": "assets/characters/shino_064/full_4S.png",
@@ -6474,11 +6474,11 @@
       "speed": 255
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2933,
     "powerWeights": {
@@ -6575,11 +6575,11 @@
       "speed": 319
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3914,
     "powerWeights": {
@@ -6657,7 +6657,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/neji_066/portrait_4S.png",
     "full": "assets/characters/neji_066/full_4S.png",
@@ -6684,11 +6684,11 @@
       "speed": 135
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5643,
     "powerWeights": {
@@ -6786,11 +6786,11 @@
       "speed": 169
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7359,
     "powerWeights": {
@@ -6869,7 +6869,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/tenten_068/portrait_4S.png",
     "full": "assets/characters/tenten_068/full_4S.png",
@@ -6896,11 +6896,11 @@
       "speed": 258
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2907,
     "powerWeights": {
@@ -6997,11 +6997,11 @@
       "speed": 323
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3780,
     "powerWeights": {
@@ -7079,7 +7079,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/hiruzen_070/portrait_4S.png",
     "full": "assets/characters/hiruzen_070/full_4S.png",
@@ -7106,11 +7106,11 @@
       "speed": 261
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2648,
     "powerWeights": {
@@ -7207,11 +7207,11 @@
       "speed": 326
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3738,
     "powerWeights": {
@@ -7289,7 +7289,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/jiraiya_072/portrait_4S.png",
     "full": "assets/characters/jiraiya_072/full_4S.png",
@@ -7316,11 +7316,11 @@
       "speed": 172
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4636,
     "powerWeights": {
@@ -7417,11 +7417,11 @@
       "speed": 214
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5774,
     "powerWeights": {
@@ -7499,7 +7499,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/orochimaru_074/portrait_4S.png",
     "full": "assets/characters/orochimaru_074/full_4S.png",
@@ -7526,11 +7526,11 @@
       "speed": 262
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2737,
     "powerWeights": {
@@ -7627,11 +7627,11 @@
       "speed": 327
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3834,
     "powerWeights": {
@@ -7709,7 +7709,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/kabuto_076/portrait_4S.png",
     "full": "assets/characters/kabuto_076/full_4S.png",
@@ -7736,11 +7736,11 @@
       "speed": 184
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4444,
     "powerWeights": {
@@ -7838,11 +7838,11 @@
       "speed": 230
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6144,
     "powerWeights": {
@@ -7921,7 +7921,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/tayuya_078/portrait_4S.png",
     "full": "assets/characters/tayuya_078/full_4S.png",
@@ -7948,11 +7948,11 @@
       "speed": 251
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3031,
     "powerWeights": {
@@ -8050,11 +8050,11 @@
       "speed": 314
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4012,
     "powerWeights": {
@@ -8133,7 +8133,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/kidomaru_080/portrait_4S.png",
     "full": "assets/characters/kidomaru_080/full_4S.png",
@@ -8160,11 +8160,11 @@
       "speed": 270
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2800,
     "powerWeights": {
@@ -8262,11 +8262,11 @@
       "speed": 337
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3604,
     "powerWeights": {
@@ -8345,7 +8345,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/sakon_082/portrait_4S.png",
     "full": "assets/characters/sakon_082/full_4S.png",
@@ -8372,11 +8372,11 @@
       "speed": 127
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5951,
     "powerWeights": {
@@ -8473,11 +8473,11 @@
       "speed": 158
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8038,
     "powerWeights": {
@@ -8555,7 +8555,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/jirobo_084/portrait_4S.png",
     "full": "assets/characters/jirobo_084/full_4S.png",
@@ -8582,11 +8582,11 @@
       "speed": 142
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5799,
     "powerWeights": {
@@ -8684,11 +8684,11 @@
       "speed": 177
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7797,
     "powerWeights": {
@@ -8767,7 +8767,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/kimimaro_086/portrait_4S.png",
     "full": "assets/characters/kimimaro_086/full_4S.png",
@@ -8794,11 +8794,11 @@
       "speed": 248
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3234,
     "powerWeights": {
@@ -8895,11 +8895,11 @@
       "speed": 310
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4370,
     "powerWeights": {
@@ -8977,7 +8977,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/itachi_088/portrait_4S.png",
     "full": "assets/characters/itachi_088/full_4S.png",
@@ -9004,11 +9004,11 @@
       "speed": 166
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4141,
     "powerWeights": {
@@ -9105,11 +9105,11 @@
       "speed": 207
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5891,
     "powerWeights": {
@@ -9187,7 +9187,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/kisame_090/portrait_4S.png",
     "full": "assets/characters/kisame_090/full_4S.png",
@@ -9214,11 +9214,11 @@
       "speed": 207
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4231,
     "powerWeights": {
@@ -9315,11 +9315,11 @@
       "speed": 259
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5753,
     "powerWeights": {
@@ -9397,7 +9397,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/ibiki_092/portrait_3S.png",
     "full": "assets/characters/ibiki_092/full_3S.png",
@@ -9424,11 +9424,11 @@
       "speed": 124
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3123,
     "powerWeights": {
@@ -9522,11 +9522,11 @@
       "speed": 155
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5439,
     "powerWeights": {
@@ -9601,7 +9601,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/anko_094/portrait_3S.png",
     "full": "assets/characters/anko_094/full_3S.png",
@@ -9628,11 +9628,11 @@
       "speed": 206
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2118,
     "powerWeights": {
@@ -9725,11 +9725,11 @@
       "speed": 257
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3523,
     "powerWeights": {
@@ -9803,7 +9803,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/hayate_096/portrait_3S.png",
     "full": "assets/characters/hayate_096/full_3S.png",
@@ -9830,11 +9830,11 @@
       "speed": 230
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 1988,
     "powerWeights": {
@@ -9927,11 +9927,11 @@
       "speed": 288
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3492,
     "powerWeights": {
@@ -10005,7 +10005,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/mizuki_098/portrait_3S.png",
     "full": "assets/characters/mizuki_098/full_3S.png",
@@ -10032,11 +10032,11 @@
       "speed": 224
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2037,
     "powerWeights": {
@@ -10129,11 +10129,11 @@
       "speed": 280
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3432,
     "powerWeights": {
@@ -10207,7 +10207,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/konohamaru_100/portrait_3S.png",
     "full": "assets/characters/konohamaru_100/full_3S.png",
@@ -10234,11 +10234,11 @@
       "speed": 236
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 1783,
     "powerWeights": {
@@ -10331,11 +10331,11 @@
       "speed": 295
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2866,
     "powerWeights": {
@@ -10409,7 +10409,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/shizune_102/portrait_3S.png",
     "full": "assets/characters/shizune_102/full_3S.png",
@@ -10436,11 +10436,11 @@
       "speed": 232
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2128,
     "powerWeights": {
@@ -10534,11 +10534,11 @@
       "speed": 290
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3551,
     "powerWeights": {
@@ -10613,7 +10613,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/baki_104/portrait_3S.png",
     "full": "assets/characters/baki_104/full_3S.png",
@@ -10640,11 +10640,11 @@
       "speed": 216
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2205,
     "powerWeights": {
@@ -10737,11 +10737,11 @@
       "speed": 270
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3657,
     "powerWeights": {
@@ -10815,7 +10815,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/kakkou_106/portrait_3S.png",
     "full": "assets/characters/kakkou_106/full_3S.png",
@@ -10842,11 +10842,11 @@
       "speed": 157
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3436,
     "powerWeights": {
@@ -10939,11 +10939,11 @@
       "speed": 196
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6199,
     "powerWeights": {
@@ -11017,7 +11017,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/shibi_108/portrait_3S.png",
     "full": "assets/characters/shibi_108/full_3S.png",
@@ -11044,11 +11044,11 @@
       "speed": 231
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 1518,
     "powerWeights": {
@@ -11141,11 +11141,11 @@
       "speed": 289
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2904,
     "powerWeights": {
@@ -11219,7 +11219,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/shikaku_110/portrait_3S.png",
     "full": "assets/characters/shikaku_110/full_3S.png",
@@ -11246,11 +11246,11 @@
       "speed": 220
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2303,
     "powerWeights": {
@@ -11343,11 +11343,11 @@
       "speed": 275
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3746,
     "powerWeights": {
@@ -11421,7 +11421,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/inoichi_112/portrait_3S.png",
     "full": "assets/characters/inoichi_112/full_3S.png",
@@ -11448,11 +11448,11 @@
       "speed": 243
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 1617,
     "powerWeights": {
@@ -11545,11 +11545,11 @@
       "speed": 304
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2910,
     "powerWeights": {
@@ -11623,7 +11623,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/choza_114/portrait_3S.png",
     "full": "assets/characters/choza_114/full_3S.png",
@@ -11650,11 +11650,11 @@
       "speed": 95
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3659,
     "powerWeights": {
@@ -11747,11 +11747,11 @@
       "speed": 119
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6097,
     "powerWeights": {
@@ -11825,7 +11825,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/hiashi_116/portrait_3S.png",
     "full": "assets/characters/hiashi_116/full_3S.png",
@@ -11852,11 +11852,11 @@
       "speed": 144
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3552,
     "powerWeights": {
@@ -11950,11 +11950,11 @@
       "speed": 180
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5724,
     "powerWeights": {
@@ -12029,7 +12029,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/hizashi_118/portrait_3S.png",
     "full": "assets/characters/hizashi_118/full_3S.png",
@@ -12056,11 +12056,11 @@
       "speed": 143
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3309,
     "powerWeights": {
@@ -12154,11 +12154,11 @@
       "speed": 179
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5578,
     "powerWeights": {
@@ -12233,7 +12233,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/tsume_120/portrait_3S.png",
     "full": "assets/characters/tsume_120/full_3S.png",
@@ -12260,11 +12260,11 @@
       "speed": 198
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2174,
     "powerWeights": {
@@ -12357,11 +12357,11 @@
       "speed": 248
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3547,
     "powerWeights": {
@@ -12458,11 +12458,11 @@
       "speed": 79
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2840,
     "powerWeights": {
@@ -12555,11 +12555,11 @@
       "speed": 233
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2223,
     "powerWeights": {
@@ -12652,11 +12652,11 @@
       "speed": 320
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 1196,
     "powerWeights": {
@@ -12750,11 +12750,11 @@
       "speed": 97
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2809,
     "powerWeights": {
@@ -12847,11 +12847,11 @@
       "speed": 293
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 1301,
     "powerWeights": {
@@ -12944,11 +12944,11 @@
       "speed": 76
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2810,
     "powerWeights": {
@@ -13041,11 +13041,11 @@
       "speed": 145
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2402,
     "powerWeights": {
@@ -13138,11 +13138,11 @@
       "speed": 229
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2067,
     "powerWeights": {
@@ -13235,11 +13235,11 @@
       "speed": 80
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3087,
     "powerWeights": {
@@ -13332,11 +13332,11 @@
       "speed": 153
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2558,
     "powerWeights": {
@@ -13429,11 +13429,11 @@
       "speed": 240
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2029,
     "powerWeights": {
@@ -13526,11 +13526,11 @@
       "speed": 149
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2368,
     "powerWeights": {
@@ -13600,7 +13600,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "3S",
+    "starMaxCode": "4S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_135/portrait_3S.png",
     "full": "assets/characters/naruto_135/full_3S.png",
@@ -13627,11 +13627,11 @@
       "speed": 199
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2264,
     "powerWeights": {
@@ -13732,11 +13732,11 @@
       "speed": 249
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3458,
     "powerWeights": {
@@ -13814,7 +13814,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/haku_137/portrait_4S.png",
     "full": "assets/characters/haku_137/full_4S.png",
@@ -13841,11 +13841,11 @@
       "speed": 189
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4268,
     "powerWeights": {
@@ -13942,11 +13942,11 @@
       "speed": 237
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5497,
     "powerWeights": {
@@ -14024,7 +14024,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/haku_139/portrait_5S.png",
     "full": "assets/characters/haku_139/full_5S.png",
@@ -14051,11 +14051,11 @@
       "speed": 254
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4369,
     "powerWeights": {
@@ -14156,11 +14156,11 @@
       "speed": 317
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6140,
     "powerWeights": {
@@ -14265,11 +14265,11 @@
       "speed": 242
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5092,
     "powerWeights": {
@@ -14348,7 +14348,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/zabuza_142/portrait_5S.png",
     "full": "assets/characters/zabuza_142/full_5S.png",
@@ -14375,11 +14375,11 @@
       "speed": 198
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5254,
     "powerWeights": {
@@ -14485,11 +14485,11 @@
       "speed": 247
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7444,
     "powerWeights": {
@@ -14576,7 +14576,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/zabuza_144/portrait_4S.png",
     "full": "assets/characters/zabuza_144/full_4S.png",
@@ -14603,11 +14603,11 @@
       "speed": 134
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4301,
     "powerWeights": {
@@ -14704,11 +14704,11 @@
       "speed": 168
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5528,
     "powerWeights": {
@@ -14786,7 +14786,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kakashi_146/portrait_5S.png",
     "full": "assets/characters/kakashi_146/full_5S.png",
@@ -14813,11 +14813,11 @@
       "speed": 149
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6278,
     "powerWeights": {
@@ -14919,11 +14919,11 @@
       "speed": 187
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8301,
     "powerWeights": {
@@ -15006,7 +15006,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/rock_148/portrait_5S.png",
     "full": "assets/characters/rock_148/full_5S.png",
@@ -15033,11 +15033,11 @@
       "speed": 163
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7197,
     "powerWeights": {
@@ -15138,11 +15138,11 @@
       "speed": 204
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9177,
     "powerWeights": {
@@ -15224,7 +15224,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/neji_150/portrait_5S.png",
     "full": "assets/characters/neji_150/full_5S.png",
@@ -15251,11 +15251,11 @@
       "speed": 83
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8519,
     "powerWeights": {
@@ -15357,11 +15357,11 @@
       "speed": 104
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10370,
     "powerWeights": {
@@ -15444,7 +15444,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sakura_152/portrait_5S.png",
     "full": "assets/characters/sakura_152/full_5S.png",
@@ -15471,11 +15471,11 @@
       "speed": 247
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3237,
     "powerWeights": {
@@ -15576,11 +15576,11 @@
       "speed": 308
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4763,
     "powerWeights": {
@@ -15662,7 +15662,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/ino_154/portrait_4S.png",
     "full": "assets/characters/ino_154/full_4S.png",
@@ -15689,11 +15689,11 @@
       "speed": 232
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3110,
     "powerWeights": {
@@ -15790,11 +15790,11 @@
       "speed": 290
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4367,
     "powerWeights": {
@@ -15872,7 +15872,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/hinata_156/portrait_4S.png",
     "full": "assets/characters/hinata_156/full_4S.png",
@@ -15899,11 +15899,11 @@
       "speed": 124
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6122,
     "powerWeights": {
@@ -16000,11 +16000,11 @@
       "speed": 155
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8337,
     "powerWeights": {
@@ -16082,7 +16082,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/rock_158/portrait_4S.png",
     "full": "assets/characters/rock_158/full_4S.png",
@@ -16109,11 +16109,11 @@
       "speed": 118
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5074,
     "powerWeights": {
@@ -16210,11 +16210,11 @@
       "speed": 147
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7130,
     "powerWeights": {
@@ -16315,11 +16315,11 @@
       "speed": 90
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7985,
     "powerWeights": {
@@ -16397,7 +16397,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_161/portrait_5S.png",
     "full": "assets/characters/naruto_161/full_5S.png",
@@ -16424,11 +16424,11 @@
       "speed": 181
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6133,
     "powerWeights": {
@@ -16529,11 +16529,11 @@
       "speed": 226
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7520,
     "powerWeights": {
@@ -16615,7 +16615,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/temari_163/portrait_4S.png",
     "full": "assets/characters/temari_163/full_4S.png",
@@ -16642,11 +16642,11 @@
       "speed": 171
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3190,
     "powerWeights": {
@@ -16744,11 +16744,11 @@
       "speed": 214
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4839,
     "powerWeights": {
@@ -16827,7 +16827,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/kankuro_165/portrait_4S.png",
     "full": "assets/characters/kankuro_165/full_4S.png",
@@ -16854,11 +16854,11 @@
       "speed": 223
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3402,
     "powerWeights": {
@@ -16955,11 +16955,11 @@
       "speed": 291
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4378,
     "powerWeights": {
@@ -17037,7 +17037,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/tsunade_167/portrait_5S.png",
     "full": "assets/characters/tsunade_167/full_5S.png",
@@ -17064,11 +17064,11 @@
       "speed": 124
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9058,
     "powerWeights": {
@@ -17170,11 +17170,11 @@
       "speed": 155
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11370,
     "powerWeights": {
@@ -17257,7 +17257,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/kabuto_169/portrait_4S.png",
     "full": "assets/characters/kabuto_169/full_4S.png",
@@ -17284,11 +17284,11 @@
       "speed": 159
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5537,
     "powerWeights": {
@@ -17386,11 +17386,11 @@
       "speed": 199
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7656,
     "powerWeights": {
@@ -17469,7 +17469,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/orochimaru_171/portrait_4S.png",
     "full": "assets/characters/orochimaru_171/full_4S.png",
@@ -17496,11 +17496,11 @@
       "speed": 91
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5915,
     "powerWeights": {
@@ -17597,11 +17597,11 @@
       "speed": 114
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8124,
     "powerWeights": {
@@ -17679,7 +17679,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/gaara_173/portrait_5S.png",
     "full": "assets/characters/gaara_173/full_5S.png",
@@ -17706,11 +17706,11 @@
       "speed": 127
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7819,
     "powerWeights": {
@@ -17811,11 +17811,11 @@
       "speed": 159
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9279,
     "powerWeights": {
@@ -17897,7 +17897,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_175/portrait_5S.png",
     "full": "assets/characters/sasuke_175/full_5S.png",
@@ -17924,11 +17924,11 @@
       "speed": 208
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5688,
     "powerWeights": {
@@ -18030,11 +18030,11 @@
       "speed": 260
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7669,
     "powerWeights": {
@@ -18117,7 +18117,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_177/portrait_5S.png",
     "full": "assets/characters/sasuke_177/full_5S.png",
@@ -18144,11 +18144,11 @@
       "speed": 107
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7992,
     "powerWeights": {
@@ -18249,11 +18249,11 @@
       "speed": 134
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9894,
     "powerWeights": {
@@ -18335,7 +18335,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_179/portrait_4S.png",
     "full": "assets/characters/naruto_179/full_4S.png",
@@ -18362,11 +18362,11 @@
       "speed": 176
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5257,
     "powerWeights": {
@@ -18463,11 +18463,11 @@
       "speed": 220
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7216,
     "powerWeights": {
@@ -18545,7 +18545,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/shikamaru_181/portrait_4S.png",
     "full": "assets/characters/shikamaru_181/full_4S.png",
@@ -18572,11 +18572,11 @@
       "speed": 116
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7342,
     "powerWeights": {
@@ -18673,11 +18673,11 @@
       "speed": 145
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9306,
     "powerWeights": {
@@ -18755,7 +18755,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/hayate_183/portrait_4S.png",
     "full": "assets/characters/hayate_183/full_4S.png",
@@ -18782,11 +18782,11 @@
       "speed": 152
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5432,
     "powerWeights": {
@@ -18883,11 +18883,11 @@
       "speed": 190
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6998,
     "powerWeights": {
@@ -18965,7 +18965,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/gaara_185/portrait_4S.png",
     "full": "assets/characters/gaara_185/full_4S.png",
@@ -18992,11 +18992,11 @@
       "speed": 48
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5887,
     "powerWeights": {
@@ -19094,11 +19094,11 @@
       "speed": 60
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8656,
     "powerWeights": {
@@ -19177,7 +19177,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/temari_187/portrait_4S.png",
     "full": "assets/characters/temari_187/full_4S.png",
@@ -19204,11 +19204,11 @@
       "speed": 116
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4525,
     "powerWeights": {
@@ -19305,11 +19305,11 @@
       "speed": 146
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5444,
     "powerWeights": {
@@ -19387,7 +19387,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/kankuro_189/portrait_4S.png",
     "full": "assets/characters/kankuro_189/full_4S.png",
@@ -19414,11 +19414,11 @@
       "speed": 148
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4193,
     "powerWeights": {
@@ -19515,11 +19515,11 @@
       "speed": 185
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5308,
     "powerWeights": {
@@ -19620,11 +19620,11 @@
       "speed": 122
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10526,
     "powerWeights": {
@@ -19702,7 +19702,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/tayuya_192/portrait_4S.png",
     "full": "assets/characters/tayuya_192/full_4S.png",
@@ -19729,11 +19729,11 @@
       "speed": 143
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5112,
     "powerWeights": {
@@ -19831,11 +19831,11 @@
       "speed": 179
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6469,
     "powerWeights": {
@@ -19914,7 +19914,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/kidomaru_194/portrait_4S.png",
     "full": "assets/characters/kidomaru_194/full_4S.png",
@@ -19941,11 +19941,11 @@
       "speed": 147
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6314,
     "powerWeights": {
@@ -20043,11 +20043,11 @@
       "speed": 184
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8519,
     "powerWeights": {
@@ -20126,7 +20126,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/sakon_196/portrait_4S.png",
     "full": "assets/characters/sakon_196/full_4S.png",
@@ -20153,11 +20153,11 @@
       "speed": 221
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3906,
     "powerWeights": {
@@ -20254,11 +20254,11 @@
       "speed": 276
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4668,
     "powerWeights": {
@@ -20336,7 +20336,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/jirobo_198/portrait_4S.png",
     "full": "assets/characters/jirobo_198/full_4S.png",
@@ -20363,11 +20363,11 @@
       "speed": 186
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4636,
     "powerWeights": {
@@ -20465,11 +20465,11 @@
       "speed": 232
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5944,
     "powerWeights": {
@@ -20548,7 +20548,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hiruzen_200/portrait_5S.png",
     "full": "assets/characters/hiruzen_200/full_5S.png",
@@ -20575,11 +20575,11 @@
       "speed": 155
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6799,
     "powerWeights": {
@@ -20680,11 +20680,11 @@
       "speed": 194
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8759,
     "powerWeights": {
@@ -20797,11 +20797,11 @@
       "speed": 51
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6198,
     "powerWeights": {
@@ -20894,11 +20894,11 @@
       "speed": 69
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7313,
     "powerWeights": {
@@ -20995,11 +20995,11 @@
       "speed": 86
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8903,
     "powerWeights": {
@@ -21108,11 +21108,11 @@
       "speed": 65
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7104,
     "powerWeights": {
@@ -21206,11 +21206,11 @@
       "speed": 87
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8522,
     "powerWeights": {
@@ -21308,11 +21308,11 @@
       "speed": 109
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11280,
     "powerWeights": {
@@ -21391,7 +21391,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/itachi_208/portrait_4S.png",
     "full": "assets/characters/itachi_208/full_4S.png",
@@ -21418,11 +21418,11 @@
       "speed": 135
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4063,
     "powerWeights": {
@@ -21519,11 +21519,11 @@
       "speed": 169
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4735,
     "powerWeights": {
@@ -21601,7 +21601,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/itachi_210/portrait_5S.png",
     "full": "assets/characters/itachi_210/full_5S.png",
@@ -21628,11 +21628,11 @@
       "speed": 218
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4823,
     "powerWeights": {
@@ -21733,11 +21733,11 @@
       "speed": 272
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6814,
     "powerWeights": {
@@ -21819,7 +21819,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/might_212/portrait_5S.png",
     "full": "assets/characters/might_212/full_5S.png",
@@ -21846,11 +21846,11 @@
       "speed": 212
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6091,
     "powerWeights": {
@@ -21951,11 +21951,11 @@
       "speed": 265
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8105,
     "powerWeights": {
@@ -22037,7 +22037,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/asuma_214/portrait_4S.png",
     "full": "assets/characters/asuma_214/full_4S.png",
@@ -22064,11 +22064,11 @@
       "speed": 102
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7042,
     "powerWeights": {
@@ -22165,11 +22165,11 @@
       "speed": 127
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10065,
     "powerWeights": {
@@ -22247,7 +22247,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/kurenai_216/portrait_4S.png",
     "full": "assets/characters/kurenai_216/full_4S.png",
@@ -22274,11 +22274,11 @@
       "speed": 125
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4900,
     "powerWeights": {
@@ -22376,11 +22376,11 @@
       "speed": 156
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6647,
     "powerWeights": {
@@ -22482,11 +22482,11 @@
       "speed": 254
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7913,
     "powerWeights": {
@@ -22568,7 +22568,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/deidara_219/portrait_5S.png",
     "full": "assets/characters/deidara_219/full_5S.png",
@@ -22595,11 +22595,11 @@
       "speed": 209
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5268,
     "powerWeights": {
@@ -22700,11 +22700,11 @@
       "speed": 261
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7018,
     "powerWeights": {
@@ -22786,7 +22786,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasori_221/portrait_5S.png",
     "full": "assets/characters/sasori_221/full_5S.png",
@@ -22813,11 +22813,11 @@
       "speed": 88
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10588,
     "powerWeights": {
@@ -22918,11 +22918,11 @@
       "speed": 110
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12006,
     "powerWeights": {
@@ -23004,7 +23004,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/kiba_223/portrait_4S.png",
     "full": "assets/characters/kiba_223/full_4S.png",
@@ -23031,11 +23031,11 @@
       "speed": 142
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6042,
     "powerWeights": {
@@ -23132,11 +23132,11 @@
       "speed": 178
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7850,
     "powerWeights": {
@@ -23214,7 +23214,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/choji_225/portrait_5S.png",
     "full": "assets/characters/choji_225/full_5S.png",
@@ -23241,11 +23241,11 @@
       "speed": 139
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8582,
     "powerWeights": {
@@ -23346,11 +23346,11 @@
       "speed": 174
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9631,
     "powerWeights": {
@@ -23432,7 +23432,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/jirobo_227/portrait_5S.png",
     "full": "assets/characters/jirobo_227/full_5S.png",
@@ -23459,11 +23459,11 @@
       "speed": 57
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8456,
     "powerWeights": {
@@ -23565,11 +23565,11 @@
       "speed": 72
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10647,
     "powerWeights": {
@@ -23652,7 +23652,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/minato_229/portrait_5S.png",
     "full": "assets/characters/minato_229/full_5S.png",
@@ -23679,11 +23679,11 @@
       "speed": 257
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4704,
     "powerWeights": {
@@ -23788,11 +23788,11 @@
       "speed": 321
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6649,
     "powerWeights": {
@@ -23878,7 +23878,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kushina_231/portrait_5S.png",
     "full": "assets/characters/kushina_231/full_5S.png",
@@ -23905,11 +23905,11 @@
       "speed": 70
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6700,
     "powerWeights": {
@@ -24007,11 +24007,11 @@
       "speed": 88
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9430,
     "powerWeights": {
@@ -24090,7 +24090,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kidomaru_233/portrait_5S.png",
     "full": "assets/characters/kidomaru_233/full_5S.png",
@@ -24117,11 +24117,11 @@
       "speed": 188
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5315,
     "powerWeights": {
@@ -24223,11 +24223,11 @@
       "speed": 235
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7778,
     "powerWeights": {
@@ -24310,7 +24310,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sakura_235/portrait_5S.png",
     "full": "assets/characters/sakura_235/full_5S.png",
@@ -24337,11 +24337,11 @@
       "speed": 134
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7138,
     "powerWeights": {
@@ -24443,11 +24443,11 @@
       "speed": 168
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9927,
     "powerWeights": {
@@ -24530,7 +24530,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_237/portrait_5S.png",
     "full": "assets/characters/naruto_237/full_5S.png",
@@ -24557,11 +24557,11 @@
       "speed": 90
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8305,
     "powerWeights": {
@@ -24662,11 +24662,11 @@
       "speed": 112
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11002,
     "powerWeights": {
@@ -24748,7 +24748,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sai_239/portrait_5S.png",
     "full": "assets/characters/sai_239/full_5S.png",
@@ -24775,11 +24775,11 @@
       "speed": 227
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4278,
     "powerWeights": {
@@ -24880,11 +24880,11 @@
       "speed": 284
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5888,
     "powerWeights": {
@@ -24989,11 +24989,11 @@
       "speed": 188
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6986,
     "powerWeights": {
@@ -25071,7 +25071,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hinata_242/portrait_5S.png",
     "full": "assets/characters/hinata_242/full_5S.png",
@@ -25098,11 +25098,11 @@
       "speed": 174
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7045,
     "powerWeights": {
@@ -25204,11 +25204,11 @@
       "speed": 217
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9964,
     "powerWeights": {
@@ -25291,7 +25291,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_244/portrait_5S.png",
     "full": "assets/characters/sasuke_244/full_5S.png",
@@ -25318,11 +25318,11 @@
       "speed": 187
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4721,
     "powerWeights": {
@@ -25423,11 +25423,11 @@
       "speed": 233
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6348,
     "powerWeights": {
@@ -25509,7 +25509,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/jiraiya_246/portrait_5S.png",
     "full": "assets/characters/jiraiya_246/full_5S.png",
@@ -25536,11 +25536,11 @@
       "speed": 41
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8319,
     "powerWeights": {
@@ -25641,11 +25641,11 @@
       "speed": 51
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10063,
     "powerWeights": {
@@ -25728,7 +25728,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/ukonsakon_248/portrait_5S.png",
     "full": "assets/characters/ukonsakon_248/full_5S.png",
@@ -25755,11 +25755,11 @@
       "speed": 89
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7377,
     "powerWeights": {
@@ -25860,11 +25860,11 @@
       "speed": 111
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9154,
     "powerWeights": {
@@ -25969,11 +25969,11 @@
       "speed": 268
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5696,
     "powerWeights": {
@@ -26051,7 +26051,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/rin_251/portrait_5S.png",
     "full": "assets/characters/rin_251/full_5S.png",
@@ -26078,11 +26078,11 @@
       "speed": 108
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11253,
     "powerWeights": {
@@ -26184,11 +26184,11 @@
       "speed": 135
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15012,
     "powerWeights": {
@@ -26271,7 +26271,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/obito_253/portrait_5S.png",
     "full": "assets/characters/obito_253/full_5S.png",
@@ -26298,11 +26298,11 @@
       "speed": 156
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6471,
     "powerWeights": {
@@ -26403,11 +26403,11 @@
       "speed": 195
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8655,
     "powerWeights": {
@@ -26489,7 +26489,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kakashi_255/portrait_5S.png",
     "full": "assets/characters/kakashi_255/full_5S.png",
@@ -26516,11 +26516,11 @@
       "speed": 199
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5315,
     "powerWeights": {
@@ -26621,11 +26621,11 @@
       "speed": 248
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8527,
     "powerWeights": {
@@ -26707,7 +26707,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/tayuya_257/portrait_5S.png",
     "full": "assets/characters/tayuya_257/full_5S.png",
@@ -26734,11 +26734,11 @@
       "speed": 170
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5111,
     "powerWeights": {
@@ -26840,11 +26840,11 @@
       "speed": 212
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6636,
     "powerWeights": {
@@ -26927,7 +26927,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_259/portrait_5S.png",
     "full": "assets/characters/naruto_259/full_5S.png",
@@ -26954,11 +26954,11 @@
       "speed": 162
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5113,
     "powerWeights": {
@@ -27059,11 +27059,11 @@
       "speed": 202
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7223,
     "powerWeights": {
@@ -27145,7 +27145,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_261/portrait_5S.png",
     "full": "assets/characters/sasuke_261/full_5S.png",
@@ -27172,11 +27172,11 @@
       "speed": 121
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8324,
     "powerWeights": {
@@ -27277,11 +27277,11 @@
       "speed": 152
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10658,
     "powerWeights": {
@@ -27363,7 +27363,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/ino_263/portrait_5S.png",
     "full": "assets/characters/ino_263/full_5S.png",
@@ -27390,11 +27390,11 @@
       "speed": 91
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8831,
     "powerWeights": {
@@ -27496,11 +27496,11 @@
       "speed": 113
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12253,
     "powerWeights": {
@@ -27583,7 +27583,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/tenten_265/portrait_5S.png",
     "full": "assets/characters/tenten_265/full_5S.png",
@@ -27610,11 +27610,11 @@
       "speed": 166
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5292,
     "powerWeights": {
@@ -27715,11 +27715,11 @@
       "speed": 207
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7861,
     "powerWeights": {
@@ -27801,7 +27801,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/gaara_267/portrait_5S.png",
     "full": "assets/characters/gaara_267/full_5S.png",
@@ -27828,11 +27828,11 @@
       "speed": 94
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8181,
     "powerWeights": {
@@ -27934,11 +27934,11 @@
       "speed": 118
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9974,
     "powerWeights": {
@@ -28021,7 +28021,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/orochimaru_269/portrait_5S.png",
     "full": "assets/characters/orochimaru_269/full_5S.png",
@@ -28048,11 +28048,11 @@
       "speed": 106
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8621,
     "powerWeights": {
@@ -28153,11 +28153,11 @@
       "speed": 133
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11416,
     "powerWeights": {
@@ -28239,7 +28239,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/yamato_271/portrait_5S.png",
     "full": "assets/characters/yamato_271/full_5S.png",
@@ -28266,11 +28266,11 @@
       "speed": 98
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10617,
     "powerWeights": {
@@ -28371,11 +28371,11 @@
       "speed": 123
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14189,
     "powerWeights": {
@@ -28457,7 +28457,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kimimaro_273/portrait_5S.png",
     "full": "assets/characters/kimimaro_273/full_5S.png",
@@ -28484,11 +28484,11 @@
       "speed": 155
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7503,
     "powerWeights": {
@@ -28589,11 +28589,11 @@
       "speed": 194
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8962,
     "powerWeights": {
@@ -28676,7 +28676,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hinata_275/portrait_5S.png",
     "full": "assets/characters/hinata_275/full_5S.png",
@@ -28703,11 +28703,11 @@
       "speed": 189
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7639,
     "powerWeights": {
@@ -28808,11 +28808,11 @@
       "speed": 236
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9702,
     "powerWeights": {
@@ -28894,7 +28894,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sakura_277/portrait_5S.png",
     "full": "assets/characters/sakura_277/full_5S.png",
@@ -28921,11 +28921,11 @@
       "speed": 119
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10439,
     "powerWeights": {
@@ -29027,11 +29027,11 @@
       "speed": 149
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12792,
     "powerWeights": {
@@ -29114,7 +29114,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/tsunade_279/portrait_5S.png",
     "full": "assets/characters/tsunade_279/full_5S.png",
@@ -29141,11 +29141,11 @@
       "speed": 180
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6206,
     "powerWeights": {
@@ -29247,11 +29247,11 @@
       "speed": 225
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9033,
     "powerWeights": {
@@ -29334,7 +29334,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_281/portrait_5S.png",
     "full": "assets/characters/naruto_281/full_5S.png",
@@ -29361,11 +29361,11 @@
       "speed": 218
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3014,
     "powerWeights": {
@@ -29462,11 +29462,11 @@
       "speed": 273
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3956,
     "powerWeights": {
@@ -29544,7 +29544,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/gaara_283/portrait_5S.png",
     "full": "assets/characters/gaara_283/full_5S.png",
@@ -29571,11 +29571,11 @@
       "speed": 142
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9211,
     "powerWeights": {
@@ -29677,11 +29677,11 @@
       "speed": 178
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12293,
     "powerWeights": {
@@ -29764,7 +29764,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/rou_285/portrait_5S.png",
     "full": "assets/characters/rou_285/full_5S.png",
@@ -29791,11 +29791,11 @@
       "speed": 146
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6729,
     "powerWeights": {
@@ -29896,11 +29896,11 @@
       "speed": 182
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8454,
     "powerWeights": {
@@ -29982,7 +29982,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/soku_287/portrait_5S.png",
     "full": "assets/characters/soku_287/full_5S.png",
@@ -30009,11 +30009,11 @@
       "speed": 202
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3788,
     "powerWeights": {
@@ -30114,11 +30114,11 @@
       "speed": 252
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5239,
     "powerWeights": {
@@ -30200,7 +30200,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/temari_289/portrait_5S.png",
     "full": "assets/characters/temari_289/full_5S.png",
@@ -30227,11 +30227,11 @@
       "speed": 91
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8300,
     "powerWeights": {
@@ -30333,11 +30333,11 @@
       "speed": 113
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10072,
     "powerWeights": {
@@ -30420,7 +30420,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/shikamaru_291/portrait_5S.png",
     "full": "assets/characters/shikamaru_291/full_5S.png",
@@ -30447,11 +30447,11 @@
       "speed": 135
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8301,
     "powerWeights": {
@@ -30553,11 +30553,11 @@
       "speed": 169
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11271,
     "powerWeights": {
@@ -30663,11 +30663,11 @@
       "speed": 363
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6237,
     "powerWeights": {
@@ -30749,7 +30749,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/rin_294/portrait_5S.png",
     "full": "assets/characters/rin_294/full_5S.png",
@@ -30776,11 +30776,11 @@
       "speed": 280
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3283,
     "powerWeights": {
@@ -30882,11 +30882,11 @@
       "speed": 350
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4573,
     "powerWeights": {
@@ -30969,7 +30969,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kushina_296/portrait_5S.png",
     "full": "assets/characters/kushina_296/full_5S.png",
@@ -30996,11 +30996,11 @@
       "speed": 114
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6442,
     "powerWeights": {
@@ -31102,11 +31102,11 @@
       "speed": 143
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8384,
     "powerWeights": {
@@ -31189,7 +31189,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/gengo_298/portrait_5S.png",
     "full": "assets/characters/gengo_298/full_5S.png",
@@ -31216,11 +31216,11 @@
       "speed": 192
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4362,
     "powerWeights": {
@@ -31321,11 +31321,11 @@
       "speed": 240
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6850,
     "powerWeights": {
@@ -31407,7 +31407,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/karin_300/portrait_5S.png",
     "full": "assets/characters/karin_300/full_5S.png",
@@ -31434,11 +31434,11 @@
       "speed": 156
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7689,
     "powerWeights": {
@@ -31539,11 +31539,11 @@
       "speed": 195
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10018,
     "powerWeights": {
@@ -31625,7 +31625,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_302/portrait_5S.png",
     "full": "assets/characters/sasuke_302/full_5S.png",
@@ -31652,11 +31652,11 @@
       "speed": 157
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6172,
     "powerWeights": {
@@ -31757,11 +31757,11 @@
       "speed": 196
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7846,
     "powerWeights": {
@@ -31843,7 +31843,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/suigetsu_304/portrait_5S.png",
     "full": "assets/characters/suigetsu_304/full_5S.png",
@@ -31870,11 +31870,11 @@
       "speed": 109
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8594,
     "powerWeights": {
@@ -31975,11 +31975,11 @@
       "speed": 136
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10654,
     "powerWeights": {
@@ -32061,7 +32061,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/jugo_306/portrait_5S.png",
     "full": "assets/characters/jugo_306/full_5S.png",
@@ -32088,11 +32088,11 @@
       "speed": 139
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5809,
     "powerWeights": {
@@ -32193,11 +32193,11 @@
       "speed": 174
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8448,
     "powerWeights": {
@@ -32279,7 +32279,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/itachi_308/portrait_5S.png",
     "full": "assets/characters/itachi_308/full_5S.png",
@@ -32306,11 +32306,11 @@
       "speed": 56
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6793,
     "powerWeights": {
@@ -32411,11 +32411,11 @@
       "speed": 70
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9440,
     "powerWeights": {
@@ -32497,7 +32497,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/utakata_310/portrait_5S.png",
     "full": "assets/characters/utakata_310/full_5S.png",
@@ -32524,11 +32524,11 @@
       "speed": 178
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6484,
     "powerWeights": {
@@ -32629,11 +32629,11 @@
       "speed": 222
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9122,
     "powerWeights": {
@@ -32738,11 +32738,11 @@
       "speed": 146
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9786,
     "powerWeights": {
@@ -32824,7 +32824,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kakashi_313/portrait_5S.png",
     "full": "assets/characters/kakashi_313/full_5S.png",
@@ -32851,11 +32851,11 @@
       "speed": 71
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9770,
     "powerWeights": {
@@ -32957,11 +32957,11 @@
       "speed": 88
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13353,
     "powerWeights": {
@@ -33044,7 +33044,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/might_315/portrait_5S.png",
     "full": "assets/characters/might_315/full_5S.png",
@@ -33071,11 +33071,11 @@
       "speed": 245
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4753,
     "powerWeights": {
@@ -33176,11 +33176,11 @@
       "speed": 306
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6091,
     "powerWeights": {
@@ -33262,7 +33262,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/tobi_317/portrait_5S.png",
     "full": "assets/characters/tobi_317/full_5S.png",
@@ -33289,11 +33289,11 @@
       "speed": 150
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5484,
     "powerWeights": {
@@ -33395,11 +33395,11 @@
       "speed": 187
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7686,
     "powerWeights": {
@@ -33482,7 +33482,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kisame_319/portrait_5S.png",
     "full": "assets/characters/kisame_319/full_5S.png",
@@ -33509,11 +33509,11 @@
       "speed": 102
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8355,
     "powerWeights": {
@@ -33615,11 +33615,11 @@
       "speed": 128
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11029,
     "powerWeights": {
@@ -33702,7 +33702,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hidan_321/portrait_5S.png",
     "full": "assets/characters/hidan_321/full_5S.png",
@@ -33729,11 +33729,11 @@
       "speed": 125
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12376,
     "powerWeights": {
@@ -33834,11 +33834,11 @@
       "speed": 156
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15717,
     "powerWeights": {
@@ -33920,7 +33920,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kakuzu_323/portrait_5S.png",
     "full": "assets/characters/kakuzu_323/full_5S.png",
@@ -33947,11 +33947,11 @@
       "speed": 176
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4849,
     "powerWeights": {
@@ -34052,11 +34052,11 @@
       "speed": 221
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6187,
     "powerWeights": {
@@ -34138,7 +34138,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/chiriku_325/portrait_5S.png",
     "full": "assets/characters/chiriku_325/full_5S.png",
@@ -34165,11 +34165,11 @@
       "speed": 105
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8018,
     "powerWeights": {
@@ -34270,11 +34270,11 @@
       "speed": 131
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9797,
     "powerWeights": {
@@ -34356,7 +34356,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_327/portrait_5S.png",
     "full": "assets/characters/naruto_327/full_5S.png",
@@ -34383,11 +34383,11 @@
       "speed": 133
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8782,
     "powerWeights": {
@@ -34488,11 +34488,11 @@
       "speed": 166
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15118,
     "powerWeights": {
@@ -34574,7 +34574,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hinata_329/portrait_5S.png",
     "full": "assets/characters/hinata_329/full_5S.png",
@@ -34601,11 +34601,11 @@
       "speed": 168
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7904,
     "powerWeights": {
@@ -34707,11 +34707,11 @@
       "speed": 209
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10300,
     "powerWeights": {
@@ -34794,7 +34794,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/yugito_331/portrait_5S.png",
     "full": "assets/characters/yugito_331/full_5S.png",
@@ -34821,11 +34821,11 @@
       "speed": 84
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9102,
     "powerWeights": {
@@ -34926,11 +34926,11 @@
       "speed": 105
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11469,
     "powerWeights": {
@@ -35012,7 +35012,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/madara_333/portrait_5S.png",
     "full": "assets/characters/madara_333/full_5S.png",
@@ -35039,11 +35039,11 @@
       "speed": 212
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8268,
     "powerWeights": {
@@ -35148,11 +35148,11 @@
       "speed": 265
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11345,
     "powerWeights": {
@@ -35238,7 +35238,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/jiraiya_335/portrait_5S.png",
     "full": "assets/characters/jiraiya_335/full_5S.png",
@@ -35265,11 +35265,11 @@
       "speed": 183
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5653,
     "powerWeights": {
@@ -35370,11 +35370,11 @@
       "speed": 229
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7533,
     "powerWeights": {
@@ -35456,7 +35456,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/konan_337/portrait_5S.png",
     "full": "assets/characters/konan_337/full_5S.png",
@@ -35483,11 +35483,11 @@
       "speed": 138
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5238,
     "powerWeights": {
@@ -35588,11 +35588,11 @@
       "speed": 173
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8191,
     "powerWeights": {
@@ -35674,7 +35674,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/chiyo_339/portrait_5S.png",
     "full": "assets/characters/chiyo_339/full_5S.png",
@@ -35701,11 +35701,11 @@
       "speed": 205
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5267,
     "powerWeights": {
@@ -35803,11 +35803,11 @@
       "speed": 256
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6754,
     "powerWeights": {
@@ -35886,7 +35886,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hanzo_341/portrait_5S.png",
     "full": "assets/characters/hanzo_341/full_5S.png",
@@ -35913,11 +35913,11 @@
       "speed": 119
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7774,
     "powerWeights": {
@@ -36018,11 +36018,11 @@
       "speed": 148
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10285,
     "powerWeights": {
@@ -36104,7 +36104,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_343/portrait_5S.png",
     "full": "assets/characters/sasuke_343/full_5S.png",
@@ -36131,11 +36131,11 @@
       "speed": 99
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8260,
     "powerWeights": {
@@ -36236,11 +36236,11 @@
       "speed": 124
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11279,
     "powerWeights": {
@@ -36345,11 +36345,11 @@
       "speed": 176
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8877,
     "powerWeights": {
@@ -36431,7 +36431,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/konohamaru_346/portrait_5S.png",
     "full": "assets/characters/konohamaru_346/full_5S.png",
@@ -36458,11 +36458,11 @@
       "speed": 118
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10284,
     "powerWeights": {
@@ -36563,11 +36563,11 @@
       "speed": 148
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13216,
     "powerWeights": {
@@ -36649,7 +36649,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_348/portrait_5S.png",
     "full": "assets/characters/naruto_348/full_5S.png",
@@ -36676,11 +36676,11 @@
       "speed": 164
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6752,
     "powerWeights": {
@@ -36781,11 +36781,11 @@
       "speed": 205
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9341,
     "powerWeights": {
@@ -36867,7 +36867,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/deidara_350/portrait_5S.png",
     "full": "assets/characters/deidara_350/full_5S.png",
@@ -36894,11 +36894,11 @@
       "speed": 180
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4373,
     "powerWeights": {
@@ -36999,11 +36999,11 @@
       "speed": 225
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5773,
     "powerWeights": {
@@ -37085,7 +37085,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/pain_352/portrait_5S.png",
     "full": "assets/characters/pain_352/full_5S.png",
@@ -37112,11 +37112,11 @@
       "speed": 179
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4815,
     "powerWeights": {
@@ -37217,11 +37217,11 @@
       "speed": 224
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7272,
     "powerWeights": {
@@ -37303,7 +37303,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/killer_354/portrait_5S.png",
     "full": "assets/characters/killer_354/full_5S.png",
@@ -37330,11 +37330,11 @@
       "speed": 171
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9112,
     "powerWeights": {
@@ -37435,11 +37435,11 @@
       "speed": 214
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11175,
     "powerWeights": {
@@ -37521,7 +37521,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/fourth_356/portrait_5S.png",
     "full": "assets/characters/fourth_356/full_5S.png",
@@ -37548,11 +37548,11 @@
       "speed": 163
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8389,
     "powerWeights": {
@@ -37653,11 +37653,11 @@
       "speed": 203
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11090,
     "powerWeights": {
@@ -37739,7 +37739,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/mei_358/portrait_5S.png",
     "full": "assets/characters/mei_358/full_5S.png",
@@ -37766,11 +37766,11 @@
       "speed": 186
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6700,
     "powerWeights": {
@@ -37871,11 +37871,11 @@
       "speed": 233
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8735,
     "powerWeights": {
@@ -37957,7 +37957,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/nagato_360/portrait_5S.png",
     "full": "assets/characters/nagato_360/full_5S.png",
@@ -37984,11 +37984,11 @@
       "speed": 147
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7174,
     "powerWeights": {
@@ -38085,11 +38085,11 @@
       "speed": 184
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9444,
     "powerWeights": {
@@ -38167,7 +38167,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/karin_362/portrait_5S.png",
     "full": "assets/characters/karin_362/full_5S.png",
@@ -38194,11 +38194,11 @@
       "speed": 178
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6571,
     "powerWeights": {
@@ -38300,11 +38300,11 @@
       "speed": 222
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9403,
     "powerWeights": {
@@ -38387,7 +38387,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sakura_364/portrait_5S.png",
     "full": "assets/characters/sakura_364/full_5S.png",
@@ -38414,11 +38414,11 @@
       "speed": 125
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9108,
     "powerWeights": {
@@ -38520,11 +38520,11 @@
       "speed": 156
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12670,
     "powerWeights": {
@@ -38607,7 +38607,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/chojuro_366/portrait_5S.png",
     "full": "assets/characters/chojuro_366/full_5S.png",
@@ -38634,11 +38634,11 @@
       "speed": 88
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7279,
     "powerWeights": {
@@ -38739,11 +38739,11 @@
       "speed": 110
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8807,
     "powerWeights": {
@@ -38825,7 +38825,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/ohnoki_368/portrait_5S.png",
     "full": "assets/characters/ohnoki_368/full_5S.png",
@@ -38852,11 +38852,11 @@
       "speed": 135
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7771,
     "powerWeights": {
@@ -38957,11 +38957,11 @@
       "speed": 169
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11088,
     "powerWeights": {
@@ -39043,7 +39043,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_370/portrait_5S.png",
     "full": "assets/characters/sasuke_370/full_5S.png",
@@ -39070,11 +39070,11 @@
       "speed": 238
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5584,
     "powerWeights": {
@@ -39175,11 +39175,11 @@
       "speed": 298
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7202,
     "powerWeights": {
@@ -39284,11 +39284,11 @@
       "speed": 264
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6187,
     "powerWeights": {
@@ -39370,7 +39370,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/danzo_373/portrait_5S.png",
     "full": "assets/characters/danzo_373/full_5S.png",
@@ -39397,11 +39397,11 @@
       "speed": 98
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7476,
     "powerWeights": {
@@ -39502,11 +39502,11 @@
       "speed": 123
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9478,
     "powerWeights": {
@@ -39588,7 +39588,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/tsunade_375/portrait_5S.png",
     "full": "assets/characters/tsunade_375/full_5S.png",
@@ -39615,11 +39615,11 @@
       "speed": 226
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4573,
     "powerWeights": {
@@ -39721,11 +39721,11 @@
       "speed": 283
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5452,
     "powerWeights": {
@@ -39808,7 +39808,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/konan_377/portrait_5S.png",
     "full": "assets/characters/konan_377/full_5S.png",
@@ -39835,11 +39835,11 @@
       "speed": 208
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5026,
     "powerWeights": {
@@ -39936,11 +39936,11 @@
       "speed": 260
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6719,
     "powerWeights": {
@@ -40018,7 +40018,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "4S",
+    "starMaxCode": "5S",
     "lbEligible": false,
     "portrait": "assets/characters/sakura_379/portrait_4S.png",
     "full": "assets/characters/sakura_379/full_4S.png",
@@ -40045,11 +40045,11 @@
       "speed": 135
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5536,
     "powerWeights": {
@@ -40139,11 +40139,11 @@
       "speed": 168
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6372,
     "powerWeights": {
@@ -40214,7 +40214,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/zetsu_381/portrait_5S.png",
     "full": "assets/characters/zetsu_381/full_5S.png",
@@ -40241,11 +40241,11 @@
       "speed": 128
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9057,
     "powerWeights": {
@@ -40346,11 +40346,11 @@
       "speed": 160
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11980,
     "powerWeights": {
@@ -40432,7 +40432,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_383/portrait_5S.png",
     "full": "assets/characters/naruto_383/full_5S.png",
@@ -40459,11 +40459,11 @@
       "speed": 194
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6067,
     "powerWeights": {
@@ -40564,11 +40564,11 @@
       "speed": 243
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8186,
     "powerWeights": {
@@ -40650,7 +40650,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/darui_385/portrait_5S.png",
     "full": "assets/characters/darui_385/full_5S.png",
@@ -40677,11 +40677,11 @@
       "speed": 181
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6632,
     "powerWeights": {
@@ -40783,11 +40783,11 @@
       "speed": 226
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9327,
     "powerWeights": {
@@ -40870,7 +40870,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/itachi_387/portrait_5S.png",
     "full": "assets/characters/itachi_387/full_5S.png",
@@ -40897,11 +40897,11 @@
       "speed": 189
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7216,
     "powerWeights": {
@@ -41002,11 +41002,11 @@
       "speed": 236
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9327,
     "powerWeights": {
@@ -41088,7 +41088,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_389/portrait_5S.png",
     "full": "assets/characters/sasuke_389/full_5S.png",
@@ -41115,11 +41115,11 @@
       "speed": 110
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10873,
     "powerWeights": {
@@ -41220,11 +41220,11 @@
       "speed": 137
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13752,
     "powerWeights": {
@@ -41329,11 +41329,11 @@
       "speed": 227
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6841,
     "powerWeights": {
@@ -41415,7 +41415,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kabuto_392/portrait_5S.png",
     "full": "assets/characters/kabuto_392/full_5S.png",
@@ -41442,11 +41442,11 @@
       "speed": 196
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4606,
     "powerWeights": {
@@ -41548,11 +41548,11 @@
       "speed": 245
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6438,
     "powerWeights": {
@@ -41635,7 +41635,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/obito_394/portrait_5S.png",
     "full": "assets/characters/obito_394/full_5S.png",
@@ -41662,11 +41662,11 @@
       "speed": 220
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7240,
     "powerWeights": {
@@ -41767,11 +41767,11 @@
       "speed": 275
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9885,
     "powerWeights": {
@@ -41853,7 +41853,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/shisui_396/portrait_5S.png",
     "full": "assets/characters/shisui_396/full_5S.png",
@@ -41880,11 +41880,11 @@
       "speed": 181
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7444,
     "powerWeights": {
@@ -41981,11 +41981,11 @@
       "speed": 266
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9648,
     "powerWeights": {
@@ -42063,7 +42063,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sakura_398/portrait_5S.png",
     "full": "assets/characters/sakura_398/full_5S.png",
@@ -42090,11 +42090,11 @@
       "speed": 168
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7389,
     "powerWeights": {
@@ -42195,11 +42195,11 @@
       "speed": 210
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10635,
     "powerWeights": {
@@ -42281,7 +42281,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_400/portrait_5S.png",
     "full": "assets/characters/naruto_400/full_5S.png",
@@ -42308,11 +42308,11 @@
       "speed": 163
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7868,
     "powerWeights": {
@@ -42413,11 +42413,11 @@
       "speed": 204
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9553,
     "powerWeights": {
@@ -42526,11 +42526,11 @@
       "speed": 102
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6643,
     "powerWeights": {
@@ -42631,11 +42631,11 @@
       "speed": 127
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9283,
     "powerWeights": {
@@ -42740,11 +42740,11 @@
       "speed": 102
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6643,
     "powerWeights": {
@@ -42845,11 +42845,11 @@
       "speed": 127
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9283,
     "powerWeights": {
@@ -42954,11 +42954,11 @@
       "speed": 115
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9243,
     "powerWeights": {
@@ -43041,7 +43041,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/tobirama_407/portrait_5S.png",
     "full": "assets/characters/tobirama_407/full_5S.png",
@@ -43068,11 +43068,11 @@
       "speed": 228
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6540,
     "powerWeights": {
@@ -43173,11 +43173,11 @@
       "speed": 285
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10185,
     "powerWeights": {
@@ -43259,7 +43259,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/minato_409/portrait_5S.png",
     "full": "assets/characters/minato_409/full_5S.png",
@@ -43286,11 +43286,11 @@
       "speed": 252
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3951,
     "powerWeights": {
@@ -43391,11 +43391,11 @@
       "speed": 315
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5335,
     "powerWeights": {
@@ -43477,7 +43477,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/obito_411/portrait_5S.png",
     "full": "assets/characters/obito_411/full_5S.png",
@@ -43504,11 +43504,11 @@
       "speed": 138
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5739,
     "powerWeights": {
@@ -43609,11 +43609,11 @@
       "speed": 172
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8577,
     "powerWeights": {
@@ -43695,7 +43695,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/fuu_413/portrait_5S.png",
     "full": "assets/characters/fuu_413/full_5S.png",
@@ -43722,11 +43722,11 @@
       "speed": 143
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6200,
     "powerWeights": {
@@ -43823,11 +43823,11 @@
       "speed": 179
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8384,
     "powerWeights": {
@@ -43905,7 +43905,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/zabuza_415/portrait_5S.png",
     "full": "assets/characters/zabuza_415/full_5S.png",
@@ -43932,11 +43932,11 @@
       "speed": 115
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9149,
     "powerWeights": {
@@ -44038,11 +44038,11 @@
       "speed": 143
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12392,
     "powerWeights": {
@@ -44125,7 +44125,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hashirama_417/portrait_5S.png",
     "full": "assets/characters/hashirama_417/full_5S.png",
@@ -44152,11 +44152,11 @@
       "speed": 193
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8248,
     "powerWeights": {
@@ -44257,11 +44257,11 @@
       "speed": 242
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10478,
     "powerWeights": {
@@ -44343,7 +44343,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_419/portrait_5S.png",
     "full": "assets/characters/sasuke_419/full_5S.png",
@@ -44370,11 +44370,11 @@
       "speed": 199
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5303,
     "powerWeights": {
@@ -44475,11 +44475,11 @@
       "speed": 249
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8014,
     "powerWeights": {
@@ -44561,7 +44561,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_421/portrait_5S.png",
     "full": "assets/characters/naruto_421/full_5S.png",
@@ -44588,11 +44588,11 @@
       "speed": 164
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5698,
     "powerWeights": {
@@ -44693,11 +44693,11 @@
       "speed": 205
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7678,
     "powerWeights": {
@@ -44779,7 +44779,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/haku_423/portrait_5S.png",
     "full": "assets/characters/haku_423/full_5S.png",
@@ -44806,11 +44806,11 @@
       "speed": 192
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6417,
     "powerWeights": {
@@ -44912,11 +44912,11 @@
       "speed": 240
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8504,
     "powerWeights": {
@@ -44999,7 +44999,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kakashi_425/portrait_5S.png",
     "full": "assets/characters/kakashi_425/full_5S.png",
@@ -45026,11 +45026,11 @@
       "speed": 144
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5692,
     "powerWeights": {
@@ -45132,11 +45132,11 @@
       "speed": 180
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8061,
     "powerWeights": {
@@ -45219,7 +45219,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_427/portrait_5S.png",
     "full": "assets/characters/naruto_427/full_5S.png",
@@ -45246,11 +45246,11 @@
       "speed": 191
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8327,
     "powerWeights": {
@@ -45355,11 +45355,11 @@
       "speed": 239
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10770,
     "powerWeights": {
@@ -45445,7 +45445,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_429/portrait_5S.png",
     "full": "assets/characters/sasuke_429/full_5S.png",
@@ -45472,11 +45472,11 @@
       "speed": 216
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7748,
     "powerWeights": {
@@ -45581,11 +45581,11 @@
       "speed": 270
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10065,
     "powerWeights": {
@@ -45694,11 +45694,11 @@
       "speed": 160
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9599,
     "powerWeights": {
@@ -45780,7 +45780,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/might_432/portrait_5S.png",
     "full": "assets/characters/might_432/full_5S.png",
@@ -45807,11 +45807,11 @@
       "speed": 194
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6419,
     "powerWeights": {
@@ -45912,11 +45912,11 @@
       "speed": 243
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8414,
     "powerWeights": {
@@ -45998,7 +45998,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/madara_434/portrait_5S.png",
     "full": "assets/characters/madara_434/full_5S.png",
@@ -46025,11 +46025,11 @@
       "speed": 182
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5610,
     "powerWeights": {
@@ -46130,11 +46130,11 @@
       "speed": 227
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7592,
     "powerWeights": {
@@ -46216,7 +46216,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/gaara_436/portrait_5S.png",
     "full": "assets/characters/gaara_436/full_5S.png",
@@ -46243,11 +46243,11 @@
       "speed": 141
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9129,
     "powerWeights": {
@@ -46349,11 +46349,11 @@
       "speed": 176
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11497,
     "powerWeights": {
@@ -46436,7 +46436,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kankuro_438/portrait_5S.png",
     "full": "assets/characters/kankuro_438/full_5S.png",
@@ -46463,11 +46463,11 @@
       "speed": 137
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6771,
     "powerWeights": {
@@ -46568,11 +46568,11 @@
       "speed": 171
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9073,
     "powerWeights": {
@@ -46654,7 +46654,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/deidara_440/portrait_5S.png",
     "full": "assets/characters/deidara_440/full_5S.png",
@@ -46681,11 +46681,11 @@
       "speed": 145
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6138,
     "powerWeights": {
@@ -46782,11 +46782,11 @@
       "speed": 182
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8193,
     "powerWeights": {
@@ -46864,7 +46864,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/rasa_442/portrait_5S.png",
     "full": "assets/characters/rasa_442/full_5S.png",
@@ -46891,11 +46891,11 @@
       "speed": 186
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3696,
     "powerWeights": {
@@ -46997,11 +46997,11 @@
       "speed": 232
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5892,
     "powerWeights": {
@@ -47084,7 +47084,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/jiraiya_444/portrait_5S.png",
     "full": "assets/characters/jiraiya_444/full_5S.png",
@@ -47111,11 +47111,11 @@
       "speed": 221
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5550,
     "powerWeights": {
@@ -47217,11 +47217,11 @@
       "speed": 276
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7846,
     "powerWeights": {
@@ -47304,7 +47304,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/orochimaru_446/portrait_5S.png",
     "full": "assets/characters/orochimaru_446/full_5S.png",
@@ -47331,11 +47331,11 @@
       "speed": 113
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11194,
     "powerWeights": {
@@ -47436,11 +47436,11 @@
       "speed": 142
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14262,
     "powerWeights": {
@@ -47545,11 +47545,11 @@
       "speed": 143
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10533,
     "powerWeights": {
@@ -47631,7 +47631,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hanzo_449/portrait_5S.png",
     "full": "assets/characters/hanzo_449/full_5S.png",
@@ -47658,11 +47658,11 @@
       "speed": 142
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4840,
     "powerWeights": {
@@ -47763,11 +47763,11 @@
       "speed": 177
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7027,
     "powerWeights": {
@@ -47849,7 +47849,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/pain_451/portrait_5S.png",
     "full": "assets/characters/pain_451/full_5S.png",
@@ -47876,11 +47876,11 @@
       "speed": 134
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11212,
     "powerWeights": {
@@ -47986,11 +47986,11 @@
       "speed": 168
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13721,
     "powerWeights": {
@@ -48104,11 +48104,11 @@
       "speed": 126
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9602,
     "powerWeights": {
@@ -48209,11 +48209,11 @@
       "speed": 158
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11745,
     "powerWeights": {
@@ -48318,11 +48318,11 @@
       "speed": 227
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12371,
     "powerWeights": {
@@ -48432,11 +48432,11 @@
       "speed": 153
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5880,
     "powerWeights": {
@@ -48537,11 +48537,11 @@
       "speed": 192
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8448,
     "powerWeights": {
@@ -48646,11 +48646,11 @@
       "speed": 204
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9380,
     "powerWeights": {
@@ -48756,11 +48756,11 @@
       "speed": 240
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8833,
     "powerWeights": {
@@ -48842,7 +48842,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/tsunade_460/portrait_5S.png",
     "full": "assets/characters/tsunade_460/full_5S.png",
@@ -48869,11 +48869,11 @@
       "speed": 80
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7745,
     "powerWeights": {
@@ -48974,11 +48974,11 @@
       "speed": 100
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12206,
     "powerWeights": {
@@ -49060,7 +49060,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/killer_462/portrait_5S.png",
     "full": "assets/characters/killer_462/full_5S.png",
@@ -49087,11 +49087,11 @@
       "speed": 131
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6613,
     "powerWeights": {
@@ -49193,11 +49193,11 @@
       "speed": 164
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8796,
     "powerWeights": {
@@ -49280,7 +49280,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/yagura_464/portrait_5S.png",
     "full": "assets/characters/yagura_464/full_5S.png",
@@ -49307,11 +49307,11 @@
       "speed": 104
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7509,
     "powerWeights": {
@@ -49408,11 +49408,11 @@
       "speed": 130
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10587,
     "powerWeights": {
@@ -49490,7 +49490,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/fourth_466/portrait_5S.png",
     "full": "assets/characters/fourth_466/full_5S.png",
@@ -49517,11 +49517,11 @@
       "speed": 166
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6342,
     "powerWeights": {
@@ -49622,11 +49622,11 @@
       "speed": 208
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8694,
     "powerWeights": {
@@ -49708,7 +49708,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/obito_468/portrait_5S.png",
     "full": "assets/characters/obito_468/full_5S.png",
@@ -49735,11 +49735,11 @@
       "speed": 148
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11293,
     "powerWeights": {
@@ -49841,11 +49841,11 @@
       "speed": 184
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14812,
     "powerWeights": {
@@ -49928,7 +49928,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/third_470/portrait_5S.png",
     "full": "assets/characters/third_470/full_5S.png",
@@ -49955,11 +49955,11 @@
       "speed": 138
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7579,
     "powerWeights": {
@@ -50061,11 +50061,11 @@
       "speed": 172
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9779,
     "powerWeights": {
@@ -50171,11 +50171,11 @@
       "speed": 195
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7276,
     "powerWeights": {
@@ -50284,11 +50284,11 @@
       "speed": 143
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7822,
     "powerWeights": {
@@ -50389,11 +50389,11 @@
       "speed": 179
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9099,
     "powerWeights": {
@@ -50498,11 +50498,11 @@
       "speed": 186
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10489,
     "powerWeights": {
@@ -50612,11 +50612,11 @@
       "speed": 242
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6237,
     "powerWeights": {
@@ -50718,11 +50718,11 @@
       "speed": 302
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7629,
     "powerWeights": {
@@ -50828,11 +50828,11 @@
       "speed": 349
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8028,
     "powerWeights": {
@@ -50938,11 +50938,11 @@
       "speed": 184
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8717,
     "powerWeights": {
@@ -51025,7 +51025,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sakura_480/portrait_5S.png",
     "full": "assets/characters/sakura_480/full_5S.png",
@@ -51052,11 +51052,11 @@
       "speed": 139
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7413,
     "powerWeights": {
@@ -51158,11 +51158,11 @@
       "speed": 173
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9884,
     "powerWeights": {
@@ -51245,7 +51245,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_482/portrait_5S.png",
     "full": "assets/characters/naruto_482/full_5S.png",
@@ -51272,11 +51272,11 @@
       "speed": 198
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4948,
     "powerWeights": {
@@ -51378,11 +51378,11 @@
       "speed": 248
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6591,
     "powerWeights": {
@@ -51465,7 +51465,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/ameyuri_484/portrait_5S.png",
     "full": "assets/characters/ameyuri_484/full_5S.png",
@@ -51492,11 +51492,11 @@
       "speed": 135
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6895,
     "powerWeights": {
@@ -51598,11 +51598,11 @@
       "speed": 169
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8854,
     "powerWeights": {
@@ -51685,7 +51685,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/might_486/portrait_5S.png",
     "full": "assets/characters/might_486/full_5S.png",
@@ -51712,11 +51712,11 @@
       "speed": 196
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5314,
     "powerWeights": {
@@ -51818,11 +51818,11 @@
       "speed": 245
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6926,
     "powerWeights": {
@@ -51905,7 +51905,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/gengetsu_488/portrait_5S.png",
     "full": "assets/characters/gengetsu_488/full_5S.png",
@@ -51932,11 +51932,11 @@
       "speed": 180
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4609,
     "powerWeights": {
@@ -52037,11 +52037,11 @@
       "speed": 225
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7097,
     "powerWeights": {
@@ -52123,7 +52123,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_490/portrait_5S.png",
     "full": "assets/characters/sasuke_490/full_5S.png",
@@ -52150,11 +52150,11 @@
       "speed": 218
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5569,
     "powerWeights": {
@@ -52255,11 +52255,11 @@
       "speed": 272
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7303,
     "powerWeights": {
@@ -52364,11 +52364,11 @@
       "speed": 237
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7564,
     "powerWeights": {
@@ -52478,11 +52478,11 @@
       "speed": 117
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6472,
     "powerWeights": {
@@ -52584,11 +52584,11 @@
       "speed": 146
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9825,
     "powerWeights": {
@@ -52694,11 +52694,11 @@
       "speed": 183
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11485,
     "powerWeights": {
@@ -52808,11 +52808,11 @@
       "speed": 235
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7184,
     "powerWeights": {
@@ -52913,11 +52913,11 @@
       "speed": 294
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9984,
     "powerWeights": {
@@ -53022,11 +53022,11 @@
       "speed": 343
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12334,
     "powerWeights": {
@@ -53132,11 +53132,11 @@
       "speed": 140
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13932,
     "powerWeights": {
@@ -53219,7 +53219,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sai_500/portrait_5S.png",
     "full": "assets/characters/sai_500/full_5S.png",
@@ -53246,11 +53246,11 @@
       "speed": 176
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9066,
     "powerWeights": {
@@ -53351,11 +53351,11 @@
       "speed": 220
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12261,
     "powerWeights": {
@@ -53437,7 +53437,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_502/portrait_5S.png",
     "full": "assets/characters/sasuke_502/full_5S.png",
@@ -53464,11 +53464,11 @@
       "speed": 166
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7893,
     "powerWeights": {
@@ -53569,11 +53569,11 @@
       "speed": 208
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10872,
     "powerWeights": {
@@ -53655,7 +53655,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/itachi_504/portrait_5S.png",
     "full": "assets/characters/itachi_504/full_5S.png",
@@ -53682,11 +53682,11 @@
       "speed": 172
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5924,
     "powerWeights": {
@@ -53787,11 +53787,11 @@
       "speed": 215
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8337,
     "powerWeights": {
@@ -53873,7 +53873,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/rock_506/portrait_5S.png",
     "full": "assets/characters/rock_506/full_5S.png",
@@ -53900,11 +53900,11 @@
       "speed": 244
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 2827,
     "powerWeights": {
@@ -54005,11 +54005,11 @@
       "speed": 305
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4594,
     "powerWeights": {
@@ -54122,11 +54122,11 @@
       "speed": 146
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9354,
     "powerWeights": {
@@ -54231,11 +54231,11 @@
       "speed": 182
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11724,
     "powerWeights": {
@@ -54321,7 +54321,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sakura_510/portrait_5S.png",
     "full": "assets/characters/sakura_510/full_5S.png",
@@ -54348,11 +54348,11 @@
       "speed": 205
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9380,
     "powerWeights": {
@@ -54458,11 +54458,11 @@
       "speed": 256
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11649,
     "powerWeights": {
@@ -54549,7 +54549,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kaguya_512/portrait_5S.png",
     "full": "assets/characters/kaguya_512/full_5S.png",
@@ -54576,11 +54576,11 @@
       "speed": 165
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5697,
     "powerWeights": {
@@ -54682,11 +54682,11 @@
       "speed": 207
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7122,
     "powerWeights": {
@@ -54792,11 +54792,11 @@
       "speed": 161
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10645,
     "powerWeights": {
@@ -54878,7 +54878,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/indra_515/portrait_5S.png",
     "full": "assets/characters/indra_515/full_5S.png",
@@ -54905,11 +54905,11 @@
       "speed": 161
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5618,
     "powerWeights": {
@@ -55010,11 +55010,11 @@
       "speed": 202
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7098,
     "powerWeights": {
@@ -55096,7 +55096,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/ashura_517/portrait_5S.png",
     "full": "assets/characters/ashura_517/full_5S.png",
@@ -55123,11 +55123,11 @@
       "speed": 122
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8415,
     "powerWeights": {
@@ -55229,11 +55229,11 @@
       "speed": 152
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11922,
     "powerWeights": {
@@ -55339,11 +55339,11 @@
       "speed": 297
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8629,
     "powerWeights": {
@@ -55452,11 +55452,11 @@
       "speed": 164
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7569,
     "powerWeights": {
@@ -55558,11 +55558,11 @@
       "speed": 205
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10136,
     "powerWeights": {
@@ -55668,11 +55668,11 @@
       "speed": 265
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10684,
     "powerWeights": {
@@ -55786,11 +55786,11 @@
       "speed": 128
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7662,
     "powerWeights": {
@@ -55892,11 +55892,11 @@
       "speed": 160
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9110,
     "powerWeights": {
@@ -56002,11 +56002,11 @@
       "speed": 206
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10366,
     "powerWeights": {
@@ -56089,7 +56089,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kurotsuchi_526/portrait_5S.png",
     "full": "assets/characters/kurotsuchi_526/full_5S.png",
@@ -56116,11 +56116,11 @@
       "speed": 206
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4156,
     "powerWeights": {
@@ -56222,11 +56222,11 @@
       "speed": 258
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6636,
     "powerWeights": {
@@ -56309,7 +56309,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/minato_528/portrait_5S.png",
     "full": "assets/characters/minato_528/full_5S.png",
@@ -56336,11 +56336,11 @@
       "speed": 244
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6133,
     "powerWeights": {
@@ -56441,11 +56441,11 @@
       "speed": 304
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8594,
     "powerWeights": {
@@ -56527,7 +56527,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kushina_530/portrait_5S.png",
     "full": "assets/characters/kushina_530/full_5S.png",
@@ -56554,11 +56554,11 @@
       "speed": 216
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6129,
     "powerWeights": {
@@ -56660,11 +56660,11 @@
       "speed": 270
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8052,
     "powerWeights": {
@@ -56747,7 +56747,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/tsunade_532/portrait_5S.png",
     "full": "assets/characters/tsunade_532/full_5S.png",
@@ -56774,11 +56774,11 @@
       "speed": 144
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6456,
     "powerWeights": {
@@ -56880,11 +56880,11 @@
       "speed": 180
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8401,
     "powerWeights": {
@@ -56967,7 +56967,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/nagato_534/portrait_5S.png",
     "full": "assets/characters/nagato_534/full_5S.png",
@@ -56994,11 +56994,11 @@
       "speed": 154
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13022,
     "powerWeights": {
@@ -57103,11 +57103,11 @@
       "speed": 193
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15919,
     "powerWeights": {
@@ -57216,11 +57216,11 @@
       "speed": 202
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7975,
     "powerWeights": {
@@ -57329,11 +57329,11 @@
       "speed": 140
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8111,
     "powerWeights": {
@@ -57435,11 +57435,11 @@
       "speed": 175
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10029,
     "powerWeights": {
@@ -57545,11 +57545,11 @@
       "speed": 254
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11918,
     "powerWeights": {
@@ -57659,11 +57659,11 @@
       "speed": 207
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4665,
     "powerWeights": {
@@ -57764,11 +57764,11 @@
       "speed": 259
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5905,
     "powerWeights": {
@@ -57873,11 +57873,11 @@
       "speed": 272
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10330,
     "powerWeights": {
@@ -57960,7 +57960,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/han_543/portrait_5S.png",
     "full": "assets/characters/han_543/full_5S.png",
@@ -57987,11 +57987,11 @@
       "speed": 202
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6292,
     "powerWeights": {
@@ -58093,11 +58093,11 @@
       "speed": 253
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8618,
     "powerWeights": {
@@ -58180,7 +58180,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kushimaru_545/portrait_5S.png",
     "full": "assets/characters/kushimaru_545/full_5S.png",
@@ -58207,11 +58207,11 @@
       "speed": 110
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7677,
     "powerWeights": {
@@ -58312,11 +58312,11 @@
       "speed": 138
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9851,
     "powerWeights": {
@@ -58398,7 +58398,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/konan_547/portrait_5S.png",
     "full": "assets/characters/konan_547/full_5S.png",
@@ -58425,11 +58425,11 @@
       "speed": 177
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8548,
     "powerWeights": {
@@ -58531,11 +58531,11 @@
       "speed": 221
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11866,
     "powerWeights": {
@@ -58618,7 +58618,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/ino_549/portrait_5S.png",
     "full": "assets/characters/ino_549/full_5S.png",
@@ -58645,11 +58645,11 @@
       "speed": 165
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6065,
     "powerWeights": {
@@ -58751,11 +58751,11 @@
       "speed": 206
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9003,
     "powerWeights": {
@@ -58838,7 +58838,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_551/portrait_5S.png",
     "full": "assets/characters/naruto_551/full_5S.png",
@@ -58865,11 +58865,11 @@
       "speed": 132
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12067,
     "powerWeights": {
@@ -58971,11 +58971,11 @@
       "speed": 165
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14690,
     "powerWeights": {
@@ -59058,7 +59058,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/roshi_553/portrait_5S.png",
     "full": "assets/characters/roshi_553/full_5S.png",
@@ -59085,11 +59085,11 @@
       "speed": 146
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6223,
     "powerWeights": {
@@ -59190,11 +59190,11 @@
       "speed": 182
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9062,
     "powerWeights": {
@@ -59299,11 +59299,11 @@
       "speed": 257
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7026,
     "powerWeights": {
@@ -59412,11 +59412,11 @@
       "speed": 181
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8063,
     "powerWeights": {
@@ -59518,11 +59518,11 @@
       "speed": 226
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10030,
     "powerWeights": {
@@ -59628,11 +59628,11 @@
       "speed": 264
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11333,
     "powerWeights": {
@@ -59742,11 +59742,11 @@
       "speed": 178
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10062,
     "powerWeights": {
@@ -59848,11 +59848,11 @@
       "speed": 223
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13393,
     "powerWeights": {
@@ -59958,11 +59958,11 @@
       "speed": 265
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14307,
     "powerWeights": {
@@ -60045,7 +60045,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/jinpachi_562/portrait_5S.png",
     "full": "assets/characters/jinpachi_562/full_5S.png",
@@ -60072,11 +60072,11 @@
       "speed": 209
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4479,
     "powerWeights": {
@@ -60177,11 +60177,11 @@
       "speed": 261
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7331,
     "powerWeights": {
@@ -60263,7 +60263,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/chojuro_564/portrait_5S.png",
     "full": "assets/characters/chojuro_564/full_5S.png",
@@ -60290,11 +60290,11 @@
       "speed": 214
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7144,
     "powerWeights": {
@@ -60395,11 +60395,11 @@
       "speed": 267
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9945,
     "powerWeights": {
@@ -60481,7 +60481,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kiba_566/portrait_5S.png",
     "full": "assets/characters/kiba_566/full_5S.png",
@@ -60508,11 +60508,11 @@
       "speed": 106
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8891,
     "powerWeights": {
@@ -60609,11 +60609,11 @@
       "speed": 132
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12514,
     "powerWeights": {
@@ -60691,7 +60691,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_568/portrait_5S.png",
     "full": "assets/characters/sasuke_568/full_5S.png",
@@ -60718,11 +60718,11 @@
       "speed": 163
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9556,
     "powerWeights": {
@@ -60828,11 +60828,11 @@
       "speed": 203
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12006,
     "powerWeights": {
@@ -60919,7 +60919,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/chino_570/portrait_5S.png",
     "full": "assets/characters/chino_570/full_5S.png",
@@ -60946,11 +60946,11 @@
       "speed": 232
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5779,
     "powerWeights": {
@@ -61052,11 +61052,11 @@
       "speed": 290
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7617,
     "powerWeights": {
@@ -61162,11 +61162,11 @@
       "speed": 166
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9515,
     "powerWeights": {
@@ -61275,11 +61275,11 @@
       "speed": 187
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8838,
     "powerWeights": {
@@ -61381,11 +61381,11 @@
       "speed": 233
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10976,
     "powerWeights": {
@@ -61491,11 +61491,11 @@
       "speed": 280
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12255,
     "powerWeights": {
@@ -61605,11 +61605,11 @@
       "speed": 254
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7528,
     "powerWeights": {
@@ -61711,11 +61711,11 @@
       "speed": 318
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9984,
     "powerWeights": {
@@ -61821,11 +61821,11 @@
       "speed": 345
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9959,
     "powerWeights": {
@@ -61908,7 +61908,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/tenten_579/portrait_5S.png",
     "full": "assets/characters/tenten_579/full_5S.png",
@@ -61935,11 +61935,11 @@
       "speed": 109
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10146,
     "powerWeights": {
@@ -62041,11 +62041,11 @@
       "speed": 137
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13979,
     "powerWeights": {
@@ -62128,7 +62128,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/jinin_581/portrait_5S.png",
     "full": "assets/characters/jinin_581/full_5S.png",
@@ -62155,11 +62155,11 @@
       "speed": 142
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5970,
     "powerWeights": {
@@ -62261,11 +62261,11 @@
       "speed": 178
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8011,
     "powerWeights": {
@@ -62348,7 +62348,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_583/portrait_5S.png",
     "full": "assets/characters/naruto_583/full_5S.png",
@@ -62375,11 +62375,11 @@
       "speed": 145
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7632,
     "powerWeights": {
@@ -62480,11 +62480,11 @@
       "speed": 181
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11849,
     "powerWeights": {
@@ -62566,7 +62566,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_585/portrait_5S.png",
     "full": "assets/characters/sasuke_585/full_5S.png",
@@ -62593,11 +62593,11 @@
       "speed": 195
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6671,
     "powerWeights": {
@@ -62699,11 +62699,11 @@
       "speed": 244
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8502,
     "powerWeights": {
@@ -62786,7 +62786,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kakashi_587/portrait_5S.png",
     "full": "assets/characters/kakashi_587/full_5S.png",
@@ -62813,11 +62813,11 @@
       "speed": 210
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4904,
     "powerWeights": {
@@ -62919,11 +62919,11 @@
       "speed": 263
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6668,
     "powerWeights": {
@@ -63006,7 +63006,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/madara_589/portrait_5S.png",
     "full": "assets/characters/madara_589/full_5S.png",
@@ -63033,11 +63033,11 @@
       "speed": 191
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10275,
     "powerWeights": {
@@ -63143,11 +63143,11 @@
       "speed": 239
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12843,
     "powerWeights": {
@@ -63234,7 +63234,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/might_591/portrait_5S.png",
     "full": "assets/characters/might_591/full_5S.png",
@@ -63261,11 +63261,11 @@
       "speed": 267
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5885,
     "powerWeights": {
@@ -63366,11 +63366,11 @@
       "speed": 334
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8469,
     "powerWeights": {
@@ -63452,7 +63452,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kaguya_593/portrait_5S.png",
     "full": "assets/characters/kaguya_593/full_5S.png",
@@ -63479,11 +63479,11 @@
       "speed": 141
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13941,
     "powerWeights": {
@@ -63589,11 +63589,11 @@
       "speed": 176
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 16352,
     "powerWeights": {
@@ -63703,11 +63703,11 @@
       "speed": 151
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12563,
     "powerWeights": {
@@ -63790,7 +63790,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/fuguki_596/portrait_5S.png",
     "full": "assets/characters/fuguki_596/full_5S.png",
@@ -63817,11 +63817,11 @@
       "speed": 103
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9057,
     "powerWeights": {
@@ -63923,11 +63923,11 @@
       "speed": 129
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11308,
     "powerWeights": {
@@ -64037,11 +64037,11 @@
       "speed": 139
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11511,
     "powerWeights": {
@@ -64143,11 +64143,11 @@
       "speed": 174
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14082,
     "powerWeights": {
@@ -64253,11 +64253,11 @@
       "speed": 188
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15812,
     "powerWeights": {
@@ -64367,11 +64367,11 @@
       "speed": 223
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6037,
     "powerWeights": {
@@ -64473,11 +64473,11 @@
       "speed": 279
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8213,
     "powerWeights": {
@@ -64583,11 +64583,11 @@
       "speed": 297
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10961,
     "powerWeights": {
@@ -64670,7 +64670,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/pain_604/portrait_5S.png",
     "full": "assets/characters/pain_604/full_5S.png",
@@ -64697,11 +64697,11 @@
       "speed": 183
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5393,
     "powerWeights": {
@@ -64798,11 +64798,11 @@
       "speed": 228
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7583,
     "powerWeights": {
@@ -64880,7 +64880,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/yagura_606/portrait_5S.png",
     "full": "assets/characters/yagura_606/full_5S.png",
@@ -64907,11 +64907,11 @@
       "speed": 167
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10702,
     "powerWeights": {
@@ -65013,11 +65013,11 @@
       "speed": 209
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13838,
     "powerWeights": {
@@ -65100,7 +65100,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/yugito_608/portrait_5S.png",
     "full": "assets/characters/yugito_608/full_5S.png",
@@ -65127,11 +65127,11 @@
       "speed": 224
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8479,
     "powerWeights": {
@@ -65232,11 +65232,11 @@
       "speed": 280
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10362,
     "powerWeights": {
@@ -65318,7 +65318,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/jiraiya_610/portrait_5S.png",
     "full": "assets/characters/jiraiya_610/full_5S.png",
@@ -65345,11 +65345,11 @@
       "speed": 219
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8037,
     "powerWeights": {
@@ -65454,11 +65454,11 @@
       "speed": 274
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10275,
     "powerWeights": {
@@ -65544,7 +65544,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/pain_612/portrait_5S.png",
     "full": "assets/characters/pain_612/full_5S.png",
@@ -65571,11 +65571,11 @@
       "speed": 122
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6357,
     "powerWeights": {
@@ -65676,11 +65676,11 @@
       "speed": 153
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8889,
     "powerWeights": {
@@ -65785,11 +65785,11 @@
       "speed": 288
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6781,
     "powerWeights": {
@@ -65899,11 +65899,11 @@
       "speed": 199
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6670,
     "powerWeights": {
@@ -66005,11 +66005,11 @@
       "speed": 249
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9718,
     "powerWeights": {
@@ -66115,11 +66115,11 @@
       "speed": 291
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10753,
     "powerWeights": {
@@ -66229,11 +66229,11 @@
       "speed": 141
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9175,
     "powerWeights": {
@@ -66334,11 +66334,11 @@
       "speed": 176
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9906,
     "powerWeights": {
@@ -66443,11 +66443,11 @@
       "speed": 198
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12656,
     "powerWeights": {
@@ -66530,7 +66530,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/suigetsu_621/portrait_5S.png",
     "full": "assets/characters/suigetsu_621/full_5S.png",
@@ -66557,11 +66557,11 @@
       "speed": 190
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7445,
     "powerWeights": {
@@ -66663,11 +66663,11 @@
       "speed": 237
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9595,
     "powerWeights": {
@@ -66750,7 +66750,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/jugo_623/portrait_5S.png",
     "full": "assets/characters/jugo_623/full_5S.png",
@@ -66777,11 +66777,11 @@
       "speed": 157
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8778,
     "powerWeights": {
@@ -66883,11 +66883,11 @@
       "speed": 196
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11547,
     "powerWeights": {
@@ -66970,7 +66970,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/torune_625/portrait_5S.png",
     "full": "assets/characters/torune_625/full_5S.png",
@@ -66997,11 +66997,11 @@
       "speed": 215
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6206,
     "powerWeights": {
@@ -67102,11 +67102,11 @@
       "speed": 269
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9072,
     "powerWeights": {
@@ -67188,7 +67188,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/minato_627/portrait_5S.png",
     "full": "assets/characters/minato_627/full_5S.png",
@@ -67215,11 +67215,11 @@
       "speed": 245
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7917,
     "powerWeights": {
@@ -67324,11 +67324,11 @@
       "speed": 306
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10184,
     "powerWeights": {
@@ -67414,7 +67414,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/mangetsu_629/portrait_5S.png",
     "full": "assets/characters/mangetsu_629/full_5S.png",
@@ -67441,11 +67441,11 @@
       "speed": 194
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4926,
     "powerWeights": {
@@ -67547,11 +67547,11 @@
       "speed": 243
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7649,
     "powerWeights": {
@@ -67634,7 +67634,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/masked_631/portrait_5S.png",
     "full": "assets/characters/masked_631/full_5S.png",
@@ -67661,11 +67661,11 @@
       "speed": 207
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 4471,
     "powerWeights": {
@@ -67766,11 +67766,11 @@
       "speed": 259
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6836,
     "powerWeights": {
@@ -67875,11 +67875,11 @@
       "speed": 180
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8944,
     "powerWeights": {
@@ -67988,11 +67988,11 @@
       "speed": 206
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6563,
     "powerWeights": {
@@ -68094,11 +68094,11 @@
       "speed": 258
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8633,
     "powerWeights": {
@@ -68204,11 +68204,11 @@
       "speed": 289
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10020,
     "powerWeights": {
@@ -68318,11 +68318,11 @@
       "speed": 105
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9669,
     "powerWeights": {
@@ -68424,11 +68424,11 @@
       "speed": 131
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11695,
     "powerWeights": {
@@ -68534,11 +68534,11 @@
       "speed": 184
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13888,
     "powerWeights": {
@@ -68621,7 +68621,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/pain_640/portrait_5S.png",
     "full": "assets/characters/pain_640/full_5S.png",
@@ -68648,11 +68648,11 @@
       "speed": 108
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9529,
     "powerWeights": {
@@ -68750,11 +68750,11 @@
       "speed": 135
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13623,
     "powerWeights": {
@@ -68833,7 +68833,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kabuto_642/portrait_5S.png",
     "full": "assets/characters/kabuto_642/full_5S.png",
@@ -68860,11 +68860,11 @@
       "speed": 204
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7375,
     "powerWeights": {
@@ -68970,11 +68970,11 @@
       "speed": 255
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10253,
     "powerWeights": {
@@ -69061,7 +69061,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasori_644/portrait_5S.png",
     "full": "assets/characters/sasori_644/full_5S.png",
@@ -69088,11 +69088,11 @@
       "speed": 111
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5036,
     "powerWeights": {
@@ -69193,11 +69193,11 @@
       "speed": 139
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6775,
     "powerWeights": {
@@ -69279,7 +69279,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/madara_646/portrait_5S.png",
     "full": "assets/characters/madara_646/full_5S.png",
@@ -69306,11 +69306,11 @@
       "speed": 135
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6883,
     "powerWeights": {
@@ -69411,11 +69411,11 @@
       "speed": 169
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9092,
     "powerWeights": {
@@ -69497,7 +69497,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/utakata_648/portrait_5S.png",
     "full": "assets/characters/utakata_648/full_5S.png",
@@ -69524,11 +69524,11 @@
       "speed": 178
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6108,
     "powerWeights": {
@@ -69630,11 +69630,11 @@
       "speed": 223
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8052,
     "powerWeights": {
@@ -69740,11 +69740,11 @@
       "speed": 199
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8229,
     "powerWeights": {
@@ -69854,11 +69854,11 @@
       "speed": 215
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7580,
     "powerWeights": {
@@ -69960,11 +69960,11 @@
       "speed": 259
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9586,
     "powerWeights": {
@@ -70070,11 +70070,11 @@
       "speed": 308
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14367,
     "powerWeights": {
@@ -70184,11 +70184,11 @@
       "speed": 159
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6238,
     "powerWeights": {
@@ -70290,11 +70290,11 @@
       "speed": 199
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8272,
     "powerWeights": {
@@ -70400,11 +70400,11 @@
       "speed": 233
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9846,
     "powerWeights": {
@@ -70487,7 +70487,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/might_657/portrait_5S.png",
     "full": "assets/characters/might_657/full_5S.png",
@@ -70514,11 +70514,11 @@
       "speed": 100
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8550,
     "powerWeights": {
@@ -70619,11 +70619,11 @@
       "speed": 125
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11148,
     "powerWeights": {
@@ -70732,11 +70732,11 @@
       "speed": 222
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11548,
     "powerWeights": {
@@ -70842,11 +70842,11 @@
       "speed": 277
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14468,
     "powerWeights": {
@@ -70960,11 +70960,11 @@
       "speed": 187
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10910,
     "powerWeights": {
@@ -71070,11 +71070,11 @@
       "speed": 234
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13512,
     "powerWeights": {
@@ -71184,11 +71184,11 @@
       "speed": 284
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7652,
     "powerWeights": {
@@ -71294,11 +71294,11 @@
       "speed": 269
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7545,
     "powerWeights": {
@@ -71404,11 +71404,11 @@
       "speed": 221
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7433,
     "powerWeights": {
@@ -71514,11 +71514,11 @@
       "speed": 283
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10250,
     "powerWeights": {
@@ -71601,7 +71601,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_667/portrait_6S.png",
     "full": "assets/characters/sasuke_667/full_6S.png",
@@ -71628,11 +71628,11 @@
       "speed": 161
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7890,
     "powerWeights": {
@@ -71738,11 +71738,11 @@
       "speed": 211
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10182,
     "powerWeights": {
@@ -71852,11 +71852,11 @@
       "speed": 161
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7501,
     "powerWeights": {
@@ -71958,11 +71958,11 @@
       "speed": 202
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10260,
     "powerWeights": {
@@ -72068,11 +72068,11 @@
       "speed": 255
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13434,
     "powerWeights": {
@@ -72182,11 +72182,11 @@
       "speed": 124
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11159,
     "powerWeights": {
@@ -72288,11 +72288,11 @@
       "speed": 167
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13083,
     "powerWeights": {
@@ -72398,11 +72398,11 @@
       "speed": 204
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15820,
     "powerWeights": {
@@ -72508,11 +72508,11 @@
       "speed": 222
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12903,
     "powerWeights": {
@@ -72594,7 +72594,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/pain_676/portrait_5S.png",
     "full": "assets/characters/pain_676/full_5S.png",
@@ -72621,11 +72621,11 @@
       "speed": 189
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8097,
     "powerWeights": {
@@ -72722,11 +72722,11 @@
       "speed": 237
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11681,
     "powerWeights": {
@@ -72804,7 +72804,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/minato_678/portrait_5S.png",
     "full": "assets/characters/minato_678/full_5S.png",
@@ -72831,11 +72831,11 @@
       "speed": 265
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7372,
     "powerWeights": {
@@ -72941,11 +72941,11 @@
       "speed": 331
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9682,
     "powerWeights": {
@@ -73032,7 +73032,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/madara_680/portrait_5S.png",
     "full": "assets/characters/madara_680/full_5S.png",
@@ -73059,11 +73059,11 @@
       "speed": 147
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11405,
     "powerWeights": {
@@ -73169,11 +73169,11 @@
       "speed": 184
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14161,
     "powerWeights": {
@@ -73260,7 +73260,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/anko_682/portrait_5S.png",
     "full": "assets/characters/anko_682/full_5S.png",
@@ -73287,11 +73287,11 @@
       "speed": 223
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 3869,
     "powerWeights": {
@@ -73392,11 +73392,11 @@
       "speed": 279
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5483,
     "powerWeights": {
@@ -73501,11 +73501,11 @@
       "speed": 299
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7263,
     "powerWeights": {
@@ -73615,11 +73615,11 @@
       "speed": 144
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10046,
     "powerWeights": {
@@ -73721,11 +73721,11 @@
       "speed": 180
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12560,
     "powerWeights": {
@@ -73831,11 +73831,11 @@
       "speed": 228
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 17351,
     "powerWeights": {
@@ -73945,11 +73945,11 @@
       "speed": 204
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6705,
     "powerWeights": {
@@ -74051,11 +74051,11 @@
       "speed": 255
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9023,
     "powerWeights": {
@@ -74161,11 +74161,11 @@
       "speed": 304
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11028,
     "powerWeights": {
@@ -74248,7 +74248,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/ino_691/portrait_5S.png",
     "full": "assets/characters/ino_691/full_5S.png",
@@ -74275,11 +74275,11 @@
       "speed": 162
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8245,
     "powerWeights": {
@@ -74380,11 +74380,11 @@
       "speed": 202
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11182,
     "powerWeights": {
@@ -74466,7 +74466,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kakuzu_693/portrait_5S.png",
     "full": "assets/characters/kakuzu_693/full_5S.png",
@@ -74493,11 +74493,11 @@
       "speed": 166
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6969,
     "powerWeights": {
@@ -74599,11 +74599,11 @@
       "speed": 207
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9602,
     "powerWeights": {
@@ -74686,7 +74686,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/madara_695/portrait_5S.png",
     "full": "assets/characters/madara_695/full_5S.png",
@@ -74713,11 +74713,11 @@
       "speed": 202
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6244,
     "powerWeights": {
@@ -74819,11 +74819,11 @@
       "speed": 253
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8296,
     "powerWeights": {
@@ -74906,7 +74906,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hashirama_697/portrait_5S.png",
     "full": "assets/characters/hashirama_697/full_5S.png",
@@ -74933,11 +74933,11 @@
       "speed": 227
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7595,
     "powerWeights": {
@@ -75039,11 +75039,11 @@
       "speed": 284
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9960,
     "powerWeights": {
@@ -75126,7 +75126,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/itachi_699/portrait_5S.png",
     "full": "assets/characters/itachi_699/full_5S.png",
@@ -75153,11 +75153,11 @@
       "speed": 189
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10958,
     "powerWeights": {
@@ -75263,11 +75263,11 @@
       "speed": 236
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13344,
     "powerWeights": {
@@ -75377,11 +75377,11 @@
       "speed": 234
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9148,
     "powerWeights": {
@@ -75463,7 +75463,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_702/portrait_6S.png",
     "full": "assets/characters/sasuke_702/full_6S.png",
@@ -75490,11 +75490,11 @@
       "speed": 192
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8273,
     "powerWeights": {
@@ -75599,11 +75599,11 @@
       "speed": 220
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10101,
     "powerWeights": {
@@ -75713,11 +75713,11 @@
       "speed": 173
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10031,
     "powerWeights": {
@@ -75819,11 +75819,11 @@
       "speed": 216
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12099,
     "powerWeights": {
@@ -75929,11 +75929,11 @@
       "speed": 259
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15678,
     "powerWeights": {
@@ -76043,11 +76043,11 @@
       "speed": 217
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7701,
     "powerWeights": {
@@ -76149,11 +76149,11 @@
       "speed": 271
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9558,
     "powerWeights": {
@@ -76259,11 +76259,11 @@
       "speed": 316
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13793,
     "powerWeights": {
@@ -76346,7 +76346,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/obito_710/portrait_5S.png",
     "full": "assets/characters/obito_710/full_5S.png",
@@ -76373,11 +76373,11 @@
       "speed": 216
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6055,
     "powerWeights": {
@@ -76479,11 +76479,11 @@
       "speed": 270
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8013,
     "powerWeights": {
@@ -76566,7 +76566,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/shizune_712/portrait_5S.png",
     "full": "assets/characters/shizune_712/full_5S.png",
@@ -76593,11 +76593,11 @@
       "speed": 165
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7441,
     "powerWeights": {
@@ -76695,11 +76695,11 @@
       "speed": 206
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10080,
     "powerWeights": {
@@ -76778,7 +76778,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/shisui_714/portrait_5S.png",
     "full": "assets/characters/shisui_714/full_5S.png",
@@ -76805,11 +76805,11 @@
       "speed": 218
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8449,
     "powerWeights": {
@@ -76915,11 +76915,11 @@
       "speed": 273
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10657,
     "powerWeights": {
@@ -77006,7 +77006,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/juzo_716/portrait_5S.png",
     "full": "assets/characters/juzo_716/full_5S.png",
@@ -77033,11 +77033,11 @@
       "speed": 108
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7520,
     "powerWeights": {
@@ -77138,11 +77138,11 @@
       "speed": 135
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9640,
     "powerWeights": {
@@ -77247,11 +77247,11 @@
       "speed": 168
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11484,
     "powerWeights": {
@@ -77333,7 +77333,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kisame_719/portrait_6S.png",
     "full": "assets/characters/kisame_719/full_6S.png",
@@ -77360,11 +77360,11 @@
       "speed": 205
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7444,
     "powerWeights": {
@@ -77470,11 +77470,11 @@
       "speed": 256
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8269,
     "powerWeights": {
@@ -77584,11 +77584,11 @@
       "speed": 181
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6937,
     "powerWeights": {
@@ -77690,11 +77690,11 @@
       "speed": 226
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9047,
     "powerWeights": {
@@ -77800,11 +77800,11 @@
       "speed": 266
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11173,
     "powerWeights": {
@@ -77914,11 +77914,11 @@
       "speed": 140
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11878,
     "powerWeights": {
@@ -78020,11 +78020,11 @@
       "speed": 175
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14357,
     "powerWeights": {
@@ -78130,11 +78130,11 @@
       "speed": 208
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 18924,
     "powerWeights": {
@@ -78217,7 +78217,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/pain_727/portrait_5S.png",
     "full": "assets/characters/pain_727/full_5S.png",
@@ -78244,11 +78244,11 @@
       "speed": 189
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7742,
     "powerWeights": {
@@ -78350,11 +78350,11 @@
       "speed": 237
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10436,
     "powerWeights": {
@@ -78437,7 +78437,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/gaara_729/portrait_5S.png",
     "full": "assets/characters/gaara_729/full_5S.png",
@@ -78464,11 +78464,11 @@
       "speed": 139
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10223,
     "powerWeights": {
@@ -78570,11 +78570,11 @@
       "speed": 174
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12719,
     "powerWeights": {
@@ -78657,7 +78657,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/deidara_731/portrait_5S.png",
     "full": "assets/characters/deidara_731/full_5S.png",
@@ -78684,11 +78684,11 @@
       "speed": 158
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7613,
     "powerWeights": {
@@ -78790,11 +78790,11 @@
       "speed": 197
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9656,
     "powerWeights": {
@@ -78900,11 +78900,11 @@
       "speed": 290
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5804,
     "powerWeights": {
@@ -78987,7 +78987,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kakashi_734/portrait_5S.png",
     "full": "assets/characters/kakashi_734/full_5S.png",
@@ -79014,11 +79014,11 @@
       "speed": 173
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11097,
     "powerWeights": {
@@ -79124,11 +79124,11 @@
       "speed": 217
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14175,
     "powerWeights": {
@@ -79215,7 +79215,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/obito_736/portrait_6S.png",
     "full": "assets/characters/obito_736/full_6S.png",
@@ -79242,11 +79242,11 @@
       "speed": 250
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8356,
     "powerWeights": {
@@ -79352,11 +79352,11 @@
       "speed": 307
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9025,
     "powerWeights": {
@@ -79462,11 +79462,11 @@
       "speed": 216
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7683,
     "powerWeights": {
@@ -79576,11 +79576,11 @@
       "speed": 250
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8088,
     "powerWeights": {
@@ -79682,11 +79682,11 @@
       "speed": 313
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10332,
     "powerWeights": {
@@ -79792,11 +79792,11 @@
       "speed": 353
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12336,
     "powerWeights": {
@@ -79902,11 +79902,11 @@
       "speed": 152
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11562,
     "powerWeights": {
@@ -80011,11 +80011,11 @@
       "speed": 184
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9835,
     "powerWeights": {
@@ -80121,11 +80121,11 @@
       "speed": 339
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7144,
     "powerWeights": {
@@ -80208,7 +80208,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hashirama_745/portrait_5S.png",
     "full": "assets/characters/hashirama_745/full_5S.png",
@@ -80235,11 +80235,11 @@
       "speed": 175
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13916,
     "powerWeights": {
@@ -80345,11 +80345,11 @@
       "speed": 218
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 17473,
     "powerWeights": {
@@ -80436,7 +80436,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/madara_747/portrait_5S.png",
     "full": "assets/characters/madara_747/full_5S.png",
@@ -80463,11 +80463,11 @@
       "speed": 233
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9446,
     "powerWeights": {
@@ -80572,11 +80572,11 @@
       "speed": 291
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12395,
     "powerWeights": {
@@ -80662,7 +80662,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kaguya_749/portrait_6S.png",
     "full": "assets/characters/kaguya_749/full_6S.png",
@@ -80689,11 +80689,11 @@
       "speed": 181
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10030,
     "powerWeights": {
@@ -80799,11 +80799,11 @@
       "speed": 247
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11692,
     "powerWeights": {
@@ -80886,7 +80886,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/izuna_751/portrait_5S.png",
     "full": "assets/characters/izuna_751/full_5S.png",
@@ -80913,11 +80913,11 @@
       "speed": 175
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5703,
     "powerWeights": {
@@ -81019,11 +81019,11 @@
       "speed": 219
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7834,
     "powerWeights": {
@@ -81129,11 +81129,11 @@
       "speed": 225
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8471,
     "powerWeights": {
@@ -81215,7 +81215,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sakura_754/portrait_5S.png",
     "full": "assets/characters/sakura_754/full_5S.png",
@@ -81242,11 +81242,11 @@
       "speed": 164
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10719,
     "powerWeights": {
@@ -81348,11 +81348,11 @@
       "speed": 205
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13392,
     "powerWeights": {
@@ -81435,7 +81435,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hinata_756/portrait_5S.png",
     "full": "assets/characters/hinata_756/full_5S.png",
@@ -81462,11 +81462,11 @@
       "speed": 124
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10144,
     "powerWeights": {
@@ -81568,11 +81568,11 @@
       "speed": 155
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12677,
     "powerWeights": {
@@ -81655,7 +81655,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/darui_758/portrait_5S.png",
     "full": "assets/characters/darui_758/full_5S.png",
@@ -81682,11 +81682,11 @@
       "speed": 198
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 5983,
     "powerWeights": {
@@ -81784,11 +81784,11 @@
       "speed": 247
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8445,
     "powerWeights": {
@@ -81867,7 +81867,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/minato_760/portrait_5S.png",
     "full": "assets/characters/minato_760/full_5S.png",
@@ -81894,11 +81894,11 @@
       "speed": 251
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9140,
     "powerWeights": {
@@ -82004,11 +82004,11 @@
       "speed": 313
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11439,
     "powerWeights": {
@@ -82095,7 +82095,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/tobirama_762/portrait_6S.png",
     "full": "assets/characters/tobirama_762/full_6S.png",
@@ -82122,11 +82122,11 @@
       "speed": 198
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8720,
     "powerWeights": {
@@ -82232,11 +82232,11 @@
       "speed": 227
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10924,
     "powerWeights": {
@@ -82342,11 +82342,11 @@
       "speed": 178
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9255,
     "powerWeights": {
@@ -82428,7 +82428,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/ao_765/portrait_5S.png",
     "full": "assets/characters/ao_765/full_5S.png",
@@ -82455,11 +82455,11 @@
       "speed": 153
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6437,
     "powerWeights": {
@@ -82560,11 +82560,11 @@
       "speed": 191
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8714,
     "powerWeights": {
@@ -82673,11 +82673,11 @@
       "speed": 197
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6559,
     "powerWeights": {
@@ -82779,11 +82779,11 @@
       "speed": 246
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9170,
     "powerWeights": {
@@ -82889,11 +82889,11 @@
       "speed": 318
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10743,
     "powerWeights": {
@@ -83003,11 +83003,11 @@
       "speed": 115
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9124,
     "powerWeights": {
@@ -83109,11 +83109,11 @@
       "speed": 144
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10936,
     "powerWeights": {
@@ -83219,11 +83219,11 @@
       "speed": 217
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13053,
     "powerWeights": {
@@ -83306,7 +83306,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hanabi_773/portrait_5S.png",
     "full": "assets/characters/hanabi_773/full_5S.png",
@@ -83333,11 +83333,11 @@
       "speed": 146
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9969,
     "powerWeights": {
@@ -83438,11 +83438,11 @@
       "speed": 183
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13651,
     "powerWeights": {
@@ -83524,7 +83524,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/izuna_775/portrait_5S.png",
     "full": "assets/characters/izuna_775/full_5S.png",
@@ -83551,11 +83551,11 @@
       "speed": 209
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8428,
     "powerWeights": {
@@ -83656,11 +83656,11 @@
       "speed": 261
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11091,
     "powerWeights": {
@@ -83765,11 +83765,11 @@
       "speed": 333
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11042,
     "powerWeights": {
@@ -83848,7 +83848,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hayate_778/portrait_5S.png",
     "full": "assets/characters/hayate_778/full_5S.png",
@@ -83875,11 +83875,11 @@
       "speed": 89
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8670,
     "powerWeights": {
@@ -83980,11 +83980,11 @@
       "speed": 122
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11579,
     "powerWeights": {
@@ -84093,11 +84093,11 @@
       "speed": 159
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8087,
     "powerWeights": {
@@ -84199,11 +84199,11 @@
       "speed": 199
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10729,
     "powerWeights": {
@@ -84309,11 +84309,11 @@
       "speed": 267
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13436,
     "powerWeights": {
@@ -84419,11 +84419,11 @@
       "speed": 301
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10696,
     "powerWeights": {
@@ -84502,7 +84502,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasori_784/portrait_5S.png",
     "full": "assets/characters/sasori_784/full_5S.png",
@@ -84529,11 +84529,11 @@
       "speed": 214
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8920,
     "powerWeights": {
@@ -84635,11 +84635,11 @@
       "speed": 267
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10870,
     "powerWeights": {
@@ -84745,11 +84745,11 @@
       "speed": 165
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11162,
     "powerWeights": {
@@ -84832,7 +84832,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/indra_787/portrait_5S.png",
     "full": "assets/characters/indra_787/full_5S.png",
@@ -84859,11 +84859,11 @@
       "speed": 209
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10567,
     "powerWeights": {
@@ -84969,11 +84969,11 @@
       "speed": 261
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13481,
     "powerWeights": {
@@ -85060,7 +85060,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/ashura_789/portrait_6S.png",
     "full": "assets/characters/ashura_789/full_6S.png",
@@ -85087,11 +85087,11 @@
       "speed": 195
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10899,
     "powerWeights": {
@@ -85197,11 +85197,11 @@
       "speed": 242
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13837,
     "powerWeights": {
@@ -85307,11 +85307,11 @@
       "speed": 341
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8069,
     "powerWeights": {
@@ -85421,11 +85421,11 @@
       "speed": 165
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12159,
     "powerWeights": {
@@ -85527,11 +85527,11 @@
       "speed": 206
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13886,
     "powerWeights": {
@@ -85637,11 +85637,11 @@
       "speed": 246
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14745,
     "powerWeights": {
@@ -85724,7 +85724,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/tenten_795/portrait_5S.png",
     "full": "assets/characters/tenten_795/full_5S.png",
@@ -85751,11 +85751,11 @@
       "speed": 168
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6137,
     "powerWeights": {
@@ -85853,11 +85853,11 @@
       "speed": 240
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8280,
     "powerWeights": {
@@ -85959,11 +85959,11 @@
       "speed": 262
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13783,
     "powerWeights": {
@@ -86042,7 +86042,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hiruzen_798/portrait_5S.png",
     "full": "assets/characters/hiruzen_798/full_5S.png",
@@ -86069,11 +86069,11 @@
       "speed": 177
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6474,
     "powerWeights": {
@@ -86174,11 +86174,11 @@
       "speed": 222
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8248,
     "powerWeights": {
@@ -86260,7 +86260,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_800/portrait_5S.png",
     "full": "assets/characters/naruto_800/full_5S.png",
@@ -86287,11 +86287,11 @@
       "speed": 227
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10637,
     "powerWeights": {
@@ -86401,11 +86401,11 @@
       "speed": 284
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13232,
     "powerWeights": {
@@ -86496,7 +86496,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_802/portrait_5S.png",
     "full": "assets/characters/sasuke_802/full_5S.png",
@@ -86523,11 +86523,11 @@
       "speed": 149
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11586,
     "powerWeights": {
@@ -86637,11 +86637,11 @@
       "speed": 186
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14707,
     "powerWeights": {
@@ -86759,11 +86759,11 @@
       "speed": 167
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10030,
     "powerWeights": {
@@ -86869,11 +86869,11 @@
       "speed": 186
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12682,
     "powerWeights": {
@@ -86979,11 +86979,11 @@
       "speed": 249
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8500,
     "powerWeights": {
@@ -87066,7 +87066,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/shikamaru_807/portrait_5S.png",
     "full": "assets/characters/shikamaru_807/full_5S.png",
@@ -87093,11 +87093,11 @@
       "speed": 198
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8315,
     "powerWeights": {
@@ -87199,11 +87199,11 @@
       "speed": 248
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10948,
     "powerWeights": {
@@ -87286,7 +87286,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/rock_809/portrait_5S.png",
     "full": "assets/characters/rock_809/full_5S.png",
@@ -87313,11 +87313,11 @@
       "speed": 174
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7751,
     "powerWeights": {
@@ -87419,11 +87419,11 @@
       "speed": 218
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10640,
     "powerWeights": {
@@ -87533,11 +87533,11 @@
       "speed": 125
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12014,
     "powerWeights": {
@@ -87639,11 +87639,11 @@
       "speed": 156
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12996,
     "powerWeights": {
@@ -87749,11 +87749,11 @@
       "speed": 192
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 19579,
     "powerWeights": {
@@ -87859,11 +87859,11 @@
       "speed": 379
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9596,
     "powerWeights": {
@@ -87942,7 +87942,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/pakura_815/portrait_5S.png",
     "full": "assets/characters/pakura_815/full_5S.png",
@@ -87969,11 +87969,11 @@
       "speed": 114
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7443,
     "powerWeights": {
@@ -88075,11 +88075,11 @@
       "speed": 142
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11361,
     "powerWeights": {
@@ -88162,7 +88162,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/pain_817/portrait_5S.png",
     "full": "assets/characters/pain_817/full_5S.png",
@@ -88189,11 +88189,11 @@
       "speed": 182
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12808,
     "powerWeights": {
@@ -88299,11 +88299,11 @@
       "speed": 228
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 16523,
     "powerWeights": {
@@ -88390,7 +88390,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_819/portrait_6S.png",
     "full": "assets/characters/naruto_819/full_6S.png",
@@ -88417,11 +88417,11 @@
       "speed": 208
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6418,
     "powerWeights": {
@@ -88527,11 +88527,11 @@
       "speed": 246
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10144,
     "powerWeights": {
@@ -88614,7 +88614,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/omoi_821/portrait_5S.png",
     "full": "assets/characters/omoi_821/full_5S.png",
@@ -88641,11 +88641,11 @@
       "speed": 177
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7830,
     "powerWeights": {
@@ -88747,11 +88747,11 @@
       "speed": 221
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10343,
     "powerWeights": {
@@ -88834,7 +88834,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/nagato_823/portrait_5S.png",
     "full": "assets/characters/nagato_823/full_5S.png",
@@ -88861,11 +88861,11 @@
       "speed": 174
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8209,
     "powerWeights": {
@@ -88967,11 +88967,11 @@
       "speed": 218
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10258,
     "powerWeights": {
@@ -89077,11 +89077,11 @@
       "speed": 256
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7741,
     "powerWeights": {
@@ -89191,11 +89191,11 @@
       "speed": 141
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9422,
     "powerWeights": {
@@ -89297,11 +89297,11 @@
       "speed": 176
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11698,
     "powerWeights": {
@@ -89407,11 +89407,11 @@
       "speed": 259
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14407,
     "powerWeights": {
@@ -89494,7 +89494,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hidan_829/portrait_5S.png",
     "full": "assets/characters/hidan_829/full_5S.png",
@@ -89521,11 +89521,11 @@
       "speed": 150
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8568,
     "powerWeights": {
@@ -89623,11 +89623,11 @@
       "speed": 187
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10715,
     "powerWeights": {
@@ -89706,7 +89706,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/orochimaru_831/portrait_5S.png",
     "full": "assets/characters/orochimaru_831/full_5S.png",
@@ -89733,11 +89733,11 @@
       "speed": 174
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7446,
     "powerWeights": {
@@ -89839,11 +89839,11 @@
       "speed": 217
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9310,
     "powerWeights": {
@@ -89949,11 +89949,11 @@
       "speed": 301
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11831,
     "powerWeights": {
@@ -90032,7 +90032,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/gaara_834/portrait_5S.png",
     "full": "assets/characters/gaara_834/full_5S.png",
@@ -90059,11 +90059,11 @@
       "speed": 168
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12345,
     "powerWeights": {
@@ -90169,11 +90169,11 @@
       "speed": 210
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15425,
     "powerWeights": {
@@ -90260,7 +90260,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/deidara_836/portrait_6S.png",
     "full": "assets/characters/deidara_836/full_6S.png",
@@ -90287,11 +90287,11 @@
       "speed": 224
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7598,
     "powerWeights": {
@@ -90396,11 +90396,11 @@
       "speed": 231
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9815,
     "powerWeights": {
@@ -90506,11 +90506,11 @@
       "speed": 191
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10788,
     "powerWeights": {
@@ -90593,7 +90593,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kushina_839/portrait_5S.png",
     "full": "assets/characters/kushina_839/full_5S.png",
@@ -90620,11 +90620,11 @@
       "speed": 179
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8066,
     "powerWeights": {
@@ -90725,11 +90725,11 @@
       "speed": 224
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10147,
     "powerWeights": {
@@ -90839,11 +90839,11 @@
       "speed": 138
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10417,
     "powerWeights": {
@@ -90945,11 +90945,11 @@
       "speed": 172
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13028,
     "powerWeights": {
@@ -91055,11 +91055,11 @@
       "speed": 258
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15369,
     "powerWeights": {
@@ -91142,7 +91142,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/izumo_844/portrait_5S.png",
     "full": "assets/characters/izumo_844/full_5S.png",
@@ -91169,11 +91169,11 @@
       "speed": 143
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7936,
     "powerWeights": {
@@ -91275,11 +91275,11 @@
       "speed": 178
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9926,
     "powerWeights": {
@@ -91362,7 +91362,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/shikamaru_846/portrait_5S.png",
     "full": "assets/characters/shikamaru_846/full_5S.png",
@@ -91389,11 +91389,11 @@
       "speed": 145
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12117,
     "powerWeights": {
@@ -91499,11 +91499,11 @@
       "speed": 181
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15135,
     "powerWeights": {
@@ -91590,7 +91590,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/asuma_848/portrait_6S.png",
     "full": "assets/characters/asuma_848/full_6S.png",
@@ -91617,11 +91617,11 @@
       "speed": 174
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7744,
     "powerWeights": {
@@ -91727,11 +91727,11 @@
       "speed": 222
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9742,
     "powerWeights": {
@@ -91837,11 +91837,11 @@
       "speed": 280
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14966,
     "powerWeights": {
@@ -91943,11 +91943,11 @@
       "speed": 174
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9884,
     "powerWeights": {
@@ -92030,7 +92030,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kotetsu_852/portrait_5S.png",
     "full": "assets/characters/kotetsu_852/full_5S.png",
@@ -92057,11 +92057,11 @@
       "speed": 171
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8480,
     "powerWeights": {
@@ -92159,11 +92159,11 @@
       "speed": 214
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10602,
     "powerWeights": {
@@ -92242,7 +92242,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kakashi_854/portrait_5S.png",
     "full": "assets/characters/kakashi_854/full_5S.png",
@@ -92269,11 +92269,11 @@
       "speed": 180
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11214,
     "powerWeights": {
@@ -92383,11 +92383,11 @@
       "speed": 225
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14011,
     "powerWeights": {
@@ -92478,7 +92478,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/obito_856/portrait_5S.png",
     "full": "assets/characters/obito_856/full_5S.png",
@@ -92505,11 +92505,11 @@
       "speed": 163
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9611,
     "powerWeights": {
@@ -92619,11 +92619,11 @@
       "speed": 203
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12014,
     "powerWeights": {
@@ -92737,11 +92737,11 @@
       "speed": 268
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12730,
     "powerWeights": {
@@ -92824,7 +92824,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/madara_859/portrait_6S.png",
     "full": "assets/characters/madara_859/full_6S.png",
@@ -92851,11 +92851,11 @@
       "speed": 192
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9358,
     "powerWeights": {
@@ -92961,11 +92961,11 @@
       "speed": 283
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11058,
     "powerWeights": {
@@ -93071,11 +93071,11 @@
       "speed": 198
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11658,
     "powerWeights": {
@@ -93185,11 +93185,11 @@
       "speed": 192
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8410,
     "powerWeights": {
@@ -93295,11 +93295,11 @@
       "speed": 240
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10508,
     "powerWeights": {
@@ -93409,11 +93409,11 @@
       "speed": 333
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14445,
     "powerWeights": {
@@ -93527,11 +93527,11 @@
       "speed": 190
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7277,
     "powerWeights": {
@@ -93637,11 +93637,11 @@
       "speed": 237
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9096,
     "powerWeights": {
@@ -93751,11 +93751,11 @@
       "speed": 333
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13055,
     "powerWeights": {
@@ -93842,7 +93842,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sakura_868/portrait_5S.png",
     "full": "assets/characters/sakura_868/full_5S.png",
@@ -93869,11 +93869,11 @@
       "speed": 140
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8554,
     "powerWeights": {
@@ -93975,11 +93975,11 @@
       "speed": 175
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10695,
     "powerWeights": {
@@ -94085,11 +94085,11 @@
       "speed": 280
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10469,
     "powerWeights": {
@@ -94168,7 +94168,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/iruka_871/portrait_5S.png",
     "full": "assets/characters/iruka_871/full_5S.png",
@@ -94195,11 +94195,11 @@
       "speed": 157
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6626,
     "powerWeights": {
@@ -94301,11 +94301,11 @@
       "speed": 209
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8286,
     "powerWeights": {
@@ -94388,7 +94388,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sai_873/portrait_5S.png",
     "full": "assets/characters/sai_873/full_5S.png",
@@ -94415,11 +94415,11 @@
       "speed": 226
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 6580,
     "powerWeights": {
@@ -94521,11 +94521,11 @@
       "speed": 282
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8392,
     "powerWeights": {
@@ -94631,11 +94631,11 @@
       "speed": 187
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10202,
     "powerWeights": {
@@ -94745,11 +94745,11 @@
       "speed": 152
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10133,
     "powerWeights": {
@@ -94851,11 +94851,11 @@
       "speed": 189
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12663,
     "powerWeights": {
@@ -94961,11 +94961,11 @@
       "speed": 274
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13144,
     "powerWeights": {
@@ -95071,11 +95071,11 @@
       "speed": 314
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11766,
     "powerWeights": {
@@ -95154,7 +95154,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/cee_880/portrait_5S.png",
     "full": "assets/characters/cee_880/full_5S.png",
@@ -95181,11 +95181,11 @@
       "speed": 166
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7434,
     "powerWeights": {
@@ -95287,11 +95287,11 @@
       "speed": 208
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9287,
     "powerWeights": {
@@ -95374,7 +95374,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasori_882/portrait_5S.png",
     "full": "assets/characters/sasori_882/full_5S.png",
@@ -95401,11 +95401,11 @@
       "speed": 165
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11424,
     "powerWeights": {
@@ -95511,11 +95511,11 @@
       "speed": 206
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14282,
     "powerWeights": {
@@ -95602,7 +95602,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/deidara_884/portrait_5S.png",
     "full": "assets/characters/deidara_884/full_5S.png",
@@ -95629,11 +95629,11 @@
       "speed": 178
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10772,
     "powerWeights": {
@@ -95739,11 +95739,11 @@
       "speed": 223
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13460,
     "powerWeights": {
@@ -95830,7 +95830,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kimimaro_886/portrait_5S.png",
     "full": "assets/characters/kimimaro_886/full_5S.png",
@@ -95857,11 +95857,11 @@
       "speed": 145
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11385,
     "powerWeights": {
@@ -95963,11 +95963,11 @@
       "speed": 181
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14225,
     "powerWeights": {
@@ -96050,7 +96050,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/orochimaru_888/portrait_6S.png",
     "full": "assets/characters/orochimaru_888/full_6S.png",
@@ -96077,11 +96077,11 @@
       "speed": 162
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8291,
     "powerWeights": {
@@ -96187,11 +96187,11 @@
       "speed": 289
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10847,
     "powerWeights": {
@@ -96297,11 +96297,11 @@
       "speed": 213
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9150,
     "powerWeights": {
@@ -96384,7 +96384,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_891/portrait_5S.png",
     "full": "assets/characters/naruto_891/full_5S.png",
@@ -96411,11 +96411,11 @@
       "speed": 261
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13986,
     "powerWeights": {
@@ -96517,11 +96517,11 @@
       "speed": 326
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 17483,
     "powerWeights": {
@@ -96631,11 +96631,11 @@
       "speed": 124
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10969,
     "powerWeights": {
@@ -96737,11 +96737,11 @@
       "speed": 155
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13712,
     "powerWeights": {
@@ -96847,11 +96847,11 @@
       "speed": 324
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15959,
     "powerWeights": {
@@ -96934,7 +96934,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/roshi_896/portrait_5S.png",
     "full": "assets/characters/roshi_896/full_5S.png",
@@ -96961,11 +96961,11 @@
       "speed": 153
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8407,
     "powerWeights": {
@@ -97063,11 +97063,11 @@
       "speed": 191
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10514,
     "powerWeights": {
@@ -97169,11 +97169,11 @@
       "speed": 365
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14096,
     "powerWeights": {
@@ -97275,11 +97275,11 @@
       "speed": 237
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9010,
     "powerWeights": {
@@ -97380,11 +97380,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -97438,11 +97438,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -97496,11 +97496,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -97554,11 +97554,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -97612,11 +97612,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -97670,11 +97670,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -97728,11 +97728,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -97786,11 +97786,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -97844,11 +97844,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -97902,11 +97902,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -97960,11 +97960,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -98018,11 +98018,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -98076,11 +98076,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -98134,11 +98134,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -98192,11 +98192,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -98250,11 +98250,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -98308,11 +98308,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -98366,11 +98366,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -98424,11 +98424,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -98482,11 +98482,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -98540,11 +98540,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -98598,11 +98598,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -98656,11 +98656,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -98696,7 +98696,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/killer_1155/portrait_6S.png",
     "full": "assets/characters/killer_1155/full_6S.png",
@@ -98723,11 +98723,11 @@
       "speed": 219
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7118,
     "powerWeights": {
@@ -98833,11 +98833,11 @@
       "speed": 285
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8612,
     "powerWeights": {
@@ -98938,11 +98938,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -98996,11 +98996,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99054,11 +99054,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99112,11 +99112,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99170,11 +99170,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99228,11 +99228,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99286,11 +99286,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99344,11 +99344,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99402,11 +99402,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99460,11 +99460,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99518,11 +99518,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99576,11 +99576,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99634,11 +99634,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99692,11 +99692,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99750,11 +99750,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99808,11 +99808,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99866,11 +99866,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99924,11 +99924,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -99982,11 +99982,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100040,11 +100040,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100098,11 +100098,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100156,11 +100156,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100214,11 +100214,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100272,11 +100272,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100330,11 +100330,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100388,11 +100388,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100446,11 +100446,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100504,11 +100504,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100562,11 +100562,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100620,11 +100620,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100678,11 +100678,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100736,11 +100736,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100794,11 +100794,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100852,11 +100852,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100910,11 +100910,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -100968,11 +100968,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -101026,11 +101026,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -101084,11 +101084,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -101142,11 +101142,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -101200,11 +101200,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -101258,11 +101258,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -101316,11 +101316,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -101374,11 +101374,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -101432,11 +101432,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -101490,11 +101490,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -101548,11 +101548,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -101606,11 +101606,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -101664,11 +101664,11 @@
       "atk": 1
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 0,
     "powerWeights": {
@@ -101704,7 +101704,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_2000/portrait_5S.png",
     "full": "assets/characters/naruto_2000/full_5S.png",
@@ -101731,11 +101731,11 @@
       "speed": 133
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7879,
     "powerWeights": {
@@ -101837,11 +101837,11 @@
       "speed": 166
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9846,
     "powerWeights": {
@@ -101924,7 +101924,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hinata_2002/portrait_5S.png",
     "full": "assets/characters/hinata_2002/full_5S.png",
@@ -101951,11 +101951,11 @@
       "speed": 242
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10841,
     "powerWeights": {
@@ -102061,11 +102061,11 @@
       "speed": 302
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13490,
     "powerWeights": {
@@ -102152,7 +102152,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/neji_2004/portrait_6S.png",
     "full": "assets/characters/neji_2004/full_6S.png",
@@ -102179,11 +102179,11 @@
       "speed": 209
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10433,
     "powerWeights": {
@@ -102289,11 +102289,11 @@
       "speed": 290
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10906,
     "powerWeights": {
@@ -102403,11 +102403,11 @@
       "speed": 198
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8247,
     "powerWeights": {
@@ -102509,11 +102509,11 @@
       "speed": 247
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10303,
     "powerWeights": {
@@ -102619,11 +102619,11 @@
       "speed": 340
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9810,
     "powerWeights": {
@@ -102729,11 +102729,11 @@
       "speed": 307
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12976,
     "powerWeights": {
@@ -102812,7 +102812,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sakumo_2010/portrait_5S.png",
     "full": "assets/characters/sakumo_2010/full_5S.png",
@@ -102839,11 +102839,11 @@
       "speed": 158
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9176,
     "powerWeights": {
@@ -102945,11 +102945,11 @@
       "speed": 198
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11475,
     "powerWeights": {
@@ -103032,7 +103032,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_2012/portrait_5S.png",
     "full": "assets/characters/sasuke_2012/full_5S.png",
@@ -103059,11 +103059,11 @@
       "speed": 261
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10612,
     "powerWeights": {
@@ -103165,11 +103165,11 @@
       "speed": 326
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13273,
     "powerWeights": {
@@ -103252,7 +103252,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/tsunade_2014/portrait_5S.png",
     "full": "assets/characters/tsunade_2014/full_5S.png",
@@ -103279,11 +103279,11 @@
       "speed": 234
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13189,
     "powerWeights": {
@@ -103389,11 +103389,11 @@
       "speed": 292
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 16491,
     "powerWeights": {
@@ -103503,11 +103503,11 @@
       "speed": 142
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11147,
     "powerWeights": {
@@ -103590,7 +103590,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hashirama_2017/portrait_6S.png",
     "full": "assets/characters/hashirama_2017/full_6S.png",
@@ -103617,11 +103617,11 @@
       "speed": 242
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7497,
     "powerWeights": {
@@ -103727,11 +103727,11 @@
       "speed": 285
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10402,
     "powerWeights": {
@@ -103841,11 +103841,11 @@
       "speed": 124
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10488,
     "powerWeights": {
@@ -103947,11 +103947,11 @@
       "speed": 155
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13112,
     "powerWeights": {
@@ -104057,11 +104057,11 @@
       "speed": 268
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 17636,
     "powerWeights": {
@@ -104144,7 +104144,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/fugaku_2022/portrait_5S.png",
     "full": "assets/characters/fugaku_2022/full_5S.png",
@@ -104171,11 +104171,11 @@
       "speed": 141
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8983,
     "powerWeights": {
@@ -104277,11 +104277,11 @@
       "speed": 176
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11222,
     "powerWeights": {
@@ -104364,7 +104364,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/madara_2024/portrait_5S.png",
     "full": "assets/characters/madara_2024/full_5S.png",
@@ -104391,11 +104391,11 @@
       "speed": 240
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12321,
     "powerWeights": {
@@ -104497,11 +104497,11 @@
       "speed": 300
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15583,
     "powerWeights": {
@@ -104584,7 +104584,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/izuna_2026/portrait_5S.png",
     "full": "assets/characters/izuna_2026/full_5S.png",
@@ -104611,11 +104611,11 @@
       "speed": 240
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11836,
     "powerWeights": {
@@ -104717,11 +104717,11 @@
       "speed": 300
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14788,
     "powerWeights": {
@@ -104827,11 +104827,11 @@
       "speed": 376
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10326,
     "powerWeights": {
@@ -104910,7 +104910,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_2029/portrait_5S.png",
     "full": "assets/characters/sasuke_2029/full_5S.png",
@@ -104937,11 +104937,11 @@
       "speed": 136
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11286,
     "powerWeights": {
@@ -105047,11 +105047,11 @@
       "speed": 170
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14105,
     "powerWeights": {
@@ -105138,7 +105138,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/itachi_2031/portrait_5S.png",
     "full": "assets/characters/itachi_2031/full_5S.png",
@@ -105165,11 +105165,11 @@
       "speed": 171
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12224,
     "powerWeights": {
@@ -105275,11 +105275,11 @@
       "speed": 213
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15274,
     "powerWeights": {
@@ -105389,11 +105389,11 @@
       "speed": 204
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10750,
     "powerWeights": {
@@ -105476,7 +105476,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/danzo_2034/portrait_6S.png",
     "full": "assets/characters/danzo_2034/full_6S.png",
@@ -105503,11 +105503,11 @@
       "speed": 260
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7541,
     "powerWeights": {
@@ -105613,11 +105613,11 @@
       "speed": 281
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9449,
     "powerWeights": {
@@ -105727,11 +105727,11 @@
       "speed": 123
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9546,
     "powerWeights": {
@@ -105833,11 +105833,11 @@
       "speed": 154
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11927,
     "powerWeights": {
@@ -105943,11 +105943,11 @@
       "speed": 327
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13520,
     "powerWeights": {
@@ -106053,11 +106053,11 @@
       "speed": 391
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11749,
     "powerWeights": {
@@ -106136,7 +106136,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/choji_2040/portrait_5S.png",
     "full": "assets/characters/choji_2040/full_5S.png",
@@ -106163,11 +106163,11 @@
       "speed": 147
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9662,
     "powerWeights": {
@@ -106269,11 +106269,11 @@
       "speed": 184
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12701,
     "powerWeights": {
@@ -106356,7 +106356,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kaguya_2042/portrait_5S.png",
     "full": "assets/characters/kaguya_2042/full_5S.png",
@@ -106383,11 +106383,11 @@
       "speed": 162
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13365,
     "powerWeights": {
@@ -106493,11 +106493,11 @@
       "speed": 203
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 16701,
     "powerWeights": {
@@ -106584,7 +106584,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hagoromo_2044/portrait_6S.png",
     "full": "assets/characters/hagoromo_2044/full_6S.png",
@@ -106611,11 +106611,11 @@
       "speed": 186
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9663,
     "powerWeights": {
@@ -106721,11 +106721,11 @@
       "speed": 244
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11381,
     "powerWeights": {
@@ -106808,7 +106808,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/tenzo_2046/portrait_5S.png",
     "full": "assets/characters/tenzo_2046/full_5S.png",
@@ -106835,11 +106835,11 @@
       "speed": 160
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7974,
     "powerWeights": {
@@ -106941,11 +106941,11 @@
       "speed": 200
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9964,
     "powerWeights": {
@@ -107028,7 +107028,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/konan_2048/portrait_5S.png",
     "full": "assets/characters/konan_2048/full_5S.png",
@@ -107055,11 +107055,11 @@
       "speed": 133
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9553,
     "powerWeights": {
@@ -107161,11 +107161,11 @@
       "speed": 167
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11939,
     "powerWeights": {
@@ -107271,11 +107271,11 @@
       "speed": 212
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8000,
     "powerWeights": {
@@ -107385,11 +107385,11 @@
       "speed": 123
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9503,
     "powerWeights": {
@@ -107491,11 +107491,11 @@
       "speed": 154
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11882,
     "powerWeights": {
@@ -107601,11 +107601,11 @@
       "speed": 319
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13301,
     "powerWeights": {
@@ -107711,11 +107711,11 @@
       "speed": 358
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14568,
     "powerWeights": {
@@ -107794,7 +107794,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kankuro_2055/portrait_5S.png",
     "full": "assets/characters/kankuro_2055/full_5S.png",
@@ -107821,11 +107821,11 @@
       "speed": 169
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8023,
     "powerWeights": {
@@ -107927,11 +107927,11 @@
       "speed": 211
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10024,
     "powerWeights": {
@@ -108014,7 +108014,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/hashirama_2057/portrait_5S.png",
     "full": "assets/characters/hashirama_2057/full_5S.png",
@@ -108041,11 +108041,11 @@
       "speed": 233
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13905,
     "powerWeights": {
@@ -108151,11 +108151,11 @@
       "speed": 292
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 17384,
     "powerWeights": {
@@ -108242,7 +108242,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/madara_2059/portrait_6S.png",
     "full": "assets/characters/madara_2059/full_6S.png",
@@ -108269,11 +108269,11 @@
       "speed": 212
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10622,
     "powerWeights": {
@@ -108379,11 +108379,11 @@
       "speed": 265
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12129,
     "powerWeights": {
@@ -108489,11 +108489,11 @@
       "speed": 138
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11558,
     "powerWeights": {
@@ -108603,11 +108603,11 @@
       "speed": 227
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8442,
     "powerWeights": {
@@ -108709,11 +108709,11 @@
       "speed": 284
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10558,
     "powerWeights": {
@@ -108819,11 +108819,11 @@
       "speed": 402
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11914,
     "powerWeights": {
@@ -108929,11 +108929,11 @@
       "speed": 382
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13168,
     "powerWeights": {
@@ -109012,7 +109012,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/dan_2066/portrait_5S.png",
     "full": "assets/characters/dan_2066/full_5S.png",
@@ -109039,11 +109039,11 @@
       "speed": 256
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7981,
     "powerWeights": {
@@ -109145,11 +109145,11 @@
       "speed": 320
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9922,
     "powerWeights": {
@@ -109255,11 +109255,11 @@
       "speed": 199
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10190,
     "powerWeights": {
@@ -109342,7 +109342,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sakura_2069/portrait_5S.png",
     "full": "assets/characters/sakura_2069/full_5S.png",
@@ -109369,11 +109369,11 @@
       "speed": 200
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10817,
     "powerWeights": {
@@ -109479,11 +109479,11 @@
       "speed": 250
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13628,
     "powerWeights": {
@@ -109570,7 +109570,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/obito_2071/portrait_6S.png",
     "full": "assets/characters/obito_2071/full_6S.png",
@@ -109597,11 +109597,11 @@
       "speed": 297
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7008,
     "powerWeights": {
@@ -109707,11 +109707,11 @@
       "speed": 303
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9628,
     "powerWeights": {
@@ -109817,11 +109817,11 @@
       "speed": 233
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10904,
     "powerWeights": {
@@ -109931,11 +109931,11 @@
       "speed": 214
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13060,
     "powerWeights": {
@@ -110037,11 +110037,11 @@
       "speed": 268
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 16368,
     "powerWeights": {
@@ -110147,11 +110147,11 @@
       "speed": 355
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 18095,
     "powerWeights": {
@@ -110257,11 +110257,11 @@
       "speed": 346
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14365,
     "powerWeights": {
@@ -110340,7 +110340,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/akatsuchi_2078/portrait_5S.png",
     "full": "assets/characters/akatsuchi_2078/full_5S.png",
@@ -110367,11 +110367,11 @@
       "speed": 159
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7076,
     "powerWeights": {
@@ -110473,11 +110473,11 @@
       "speed": 199
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10434,
     "powerWeights": {
@@ -110560,7 +110560,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/obito_2080/portrait_5S.png",
     "full": "assets/characters/obito_2080/full_5S.png",
@@ -110587,11 +110587,11 @@
       "speed": 201
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11627,
     "powerWeights": {
@@ -110697,11 +110697,11 @@
       "speed": 251
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14658,
     "powerWeights": {
@@ -110811,11 +110811,11 @@
       "speed": 267
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9931,
     "powerWeights": {
@@ -110921,11 +110921,11 @@
       "speed": 320
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12538,
     "powerWeights": {
@@ -111031,11 +111031,11 @@
       "speed": 362
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13590,
     "powerWeights": {
@@ -111144,11 +111144,11 @@
       "speed": 157
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12705,
     "powerWeights": {
@@ -111250,11 +111250,11 @@
       "speed": 197
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15645,
     "powerWeights": {
@@ -111360,11 +111360,11 @@
       "speed": 357
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 19118,
     "powerWeights": {
@@ -111470,11 +111470,11 @@
       "speed": 335
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 17453,
     "powerWeights": {
@@ -111553,7 +111553,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "7S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_2089/portrait_6S.png",
     "full": "assets/characters/naruto_2089/full_6S.png",
@@ -111584,11 +111584,11 @@
       "speed": 288
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12163,
     "powerWeights": {
@@ -111694,11 +111694,11 @@
       "speed": 360
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 16873,
     "powerWeights": {
@@ -111808,11 +111808,11 @@
       "speed": 253
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15864,
     "powerWeights": {
@@ -111925,11 +111925,11 @@
       "speed": 265
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12797,
     "powerWeights": {
@@ -112035,11 +112035,11 @@
       "speed": 310
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10537,
     "powerWeights": {
@@ -112149,11 +112149,11 @@
       "speed": 188
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9994,
     "powerWeights": {
@@ -112255,11 +112255,11 @@
       "speed": 235
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12293,
     "powerWeights": {
@@ -112365,11 +112365,11 @@
       "speed": 360
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13997,
     "powerWeights": {
@@ -112475,11 +112475,11 @@
       "speed": 367
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15204,
     "powerWeights": {
@@ -112581,11 +112581,11 @@
       "speed": 308
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15249,
     "powerWeights": {
@@ -112695,11 +112695,11 @@
       "speed": 270
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10548,
     "powerWeights": {
@@ -112782,7 +112782,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/minato_2100/portrait_5S.png",
     "full": "assets/characters/minato_2100/full_5S.png",
@@ -112809,11 +112809,11 @@
       "speed": 243
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11273,
     "powerWeights": {
@@ -112919,11 +112919,11 @@
       "speed": 304
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14036,
     "powerWeights": {
@@ -113010,7 +113010,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/masked_2102/portrait_6S.png",
     "full": "assets/characters/masked_2102/full_6S.png",
@@ -113037,11 +113037,11 @@
       "speed": 280
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7635,
     "powerWeights": {
@@ -113147,11 +113147,11 @@
       "speed": 328
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10787,
     "powerWeights": {
@@ -113257,11 +113257,11 @@
       "speed": 258
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11061,
     "powerWeights": {
@@ -113371,11 +113371,11 @@
       "speed": 178
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11544,
     "powerWeights": {
@@ -113477,11 +113477,11 @@
       "speed": 222
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13740,
     "powerWeights": {
@@ -113587,11 +113587,11 @@
       "speed": 311
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15587,
     "powerWeights": {
@@ -113697,11 +113697,11 @@
       "speed": 352
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15117,
     "powerWeights": {
@@ -113780,7 +113780,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/ashura_2109/portrait_5S.png",
     "full": "assets/characters/ashura_2109/full_5S.png",
@@ -113807,11 +113807,11 @@
       "speed": 251
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13585,
     "powerWeights": {
@@ -113917,11 +113917,11 @@
       "speed": 313
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 17074,
     "powerWeights": {
@@ -114008,7 +114008,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/indra_2111/portrait_6S.png",
     "full": "assets/characters/indra_2111/full_6S.png",
@@ -114035,11 +114035,11 @@
       "speed": 261
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 10610,
     "powerWeights": {
@@ -114145,11 +114145,11 @@
       "speed": 310
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12614,
     "powerWeights": {
@@ -114255,11 +114255,11 @@
       "speed": 272
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11168,
     "powerWeights": {
@@ -114342,7 +114342,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "7S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_2114/portrait_6S.png",
     "full": "assets/characters/naruto_2114/full_6S.png",
@@ -114373,11 +114373,11 @@
       "speed": 298
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 17096,
     "powerWeights": {
@@ -114483,11 +114483,11 @@
       "speed": 372
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 23932,
     "powerWeights": {
@@ -114574,7 +114574,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "6SB",
+    "starMaxCode": "7S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_2116/portrait_6S.png",
     "full": "assets/characters/sasuke_2116/full_6S.png",
@@ -114605,11 +114605,11 @@
       "speed": 312
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12011,
     "powerWeights": {
@@ -114715,11 +114715,11 @@
       "speed": 391
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 18013,
     "powerWeights": {
@@ -114829,11 +114829,11 @@
       "speed": 328
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12906,
     "powerWeights": {
@@ -114939,11 +114939,11 @@
       "speed": 317
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14399,
     "powerWeights": {
@@ -115053,11 +115053,11 @@
       "speed": 226
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 7682,
     "powerWeights": {
@@ -115159,11 +115159,11 @@
       "speed": 282
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11803,
     "powerWeights": {
@@ -115269,11 +115269,11 @@
       "speed": 363
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 13663,
     "powerWeights": {
@@ -115379,11 +115379,11 @@
       "speed": 340
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 16339,
     "powerWeights": {
@@ -115485,11 +115485,11 @@
       "speed": 241
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11664,
     "powerWeights": {
@@ -115572,7 +115572,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/kakashi_2125/portrait_5S.png",
     "full": "assets/characters/kakashi_2125/full_5S.png",
@@ -115599,11 +115599,11 @@
       "speed": 253
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 8816,
     "powerWeights": {
@@ -115705,11 +115705,11 @@
       "speed": 317
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11957,
     "powerWeights": {
@@ -115815,11 +115815,11 @@
       "speed": 271
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12854,
     "powerWeights": {
@@ -115929,11 +115929,11 @@
       "speed": 217
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 12676,
     "powerWeights": {
@@ -116035,11 +116035,11 @@
       "speed": 271
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14467,
     "powerWeights": {
@@ -116145,11 +116145,11 @@
       "speed": 375
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 17260,
     "powerWeights": {
@@ -116232,7 +116232,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/sasuke_2131/portrait_5S.png",
     "full": "assets/characters/sasuke_2131/full_5S.png",
@@ -116259,11 +116259,11 @@
       "speed": 266
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15763,
     "powerWeights": {
@@ -116369,11 +116369,11 @@
       "speed": 332
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 19668,
     "powerWeights": {
@@ -116483,11 +116483,11 @@
       "speed": 282
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14441,
     "powerWeights": {
@@ -116597,11 +116597,11 @@
       "speed": 242
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 9391,
     "powerWeights": {
@@ -116703,11 +116703,11 @@
       "speed": 302
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11553,
     "powerWeights": {
@@ -116813,11 +116813,11 @@
       "speed": 358
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15025,
     "powerWeights": {
@@ -116900,7 +116900,7 @@
     "element": null,
     "rarity": 1,
     "starMinCode": "1S",
-    "starMaxCode": "5S",
+    "starMaxCode": "6S",
     "lbEligible": false,
     "portrait": "assets/characters/naruto_2137/portrait_5S.png",
     "full": "assets/characters/naruto_2137/full_5S.png",
@@ -116927,11 +116927,11 @@
       "speed": 257
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 15930,
     "powerWeights": {
@@ -117037,11 +117037,11 @@
       "speed": 322
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 19643,
     "powerWeights": {
@@ -117155,11 +117155,11 @@
       "speed": 208
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 11823,
     "powerWeights": {
@@ -117261,11 +117261,11 @@
       "speed": 260
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 14498,
     "powerWeights": {
@@ -117371,11 +117371,11 @@
       "speed": 391
     },
     "growthCurve": {
-      "hp": 1.0,
-      "atk": 1.0,
-      "def": 1.0,
-      "speed": 1.0,
-      "chakra": 1.0
+      "hp": 1,
+      "atk": 1,
+      "def": 1,
+      "speed": 1,
+      "chakra": 1
     },
     "powerRank": 17179,
     "powerWeights": {


### PR DESCRIPTION
PROBLEM:
- Only characters 659 (Naruto) and 661 (Sasuke) could awaken
- All other 367 characters with awakening transformations failed to show the awakening option

ROOT CAUSE:
- The awakening system checks if a character can promote to the next tier by comparing current tier with starMaxCode
- Most characters had starMaxCode set to their base tier (e.g., "5S") instead of their awakening target tier (e.g., "6S")
- This caused canPromoteTier() to return false, blocking awakening

SOLUTION:
- Updated starMaxCode for all 365 broken characters to match their awakening transformation tier from awakening-transforms.json
- Characters 659 and 661 already had correct starMaxCode values

VERIFICATION:
- All 369 characters with awakening transformations now have matching starMaxCode and transformation tier values
- Awakening button will now be enabled for all characters at max level