### PR TITLE
Fix chakra visualization and character switching issues

### DIFF
--- a/css/battle-chakra-wheel.css
+++ b/css/battle-chakra-wheel.css
@@ -87,6 +87,16 @@
   opacity: 1;
 }
 
+/* Jutsu range segments (blue-ish tint) */
+.chakra-segment.active.jutsu-range {
+  filter: brightness(1.1) hue-rotate(-10deg);
+}
+
+/* Ultimate range segments (stronger, more intense) */
+.chakra-segment.active.ultimate-range {
+  filter: brightness(1.3) saturate(1.4);
+}
+
 /* =========================================
    CHAKRA HOLDER FRAME (TOP LAYER, z-index: 10)
    ========================================= */

--- a/css/battle-team-holder.css
+++ b/css/battle-team-holder.css
@@ -145,10 +145,14 @@
 /* Switch animation states */
 .active-portrait-container.switching {
   animation: activeSpin 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  filter: brightness(1.3) drop-shadow(0 0 10px rgba(100, 180, 255, 0.8));
+  z-index: 100;
 }
 
 .bench-portrait-container.switching {
   animation: benchSwap 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  filter: brightness(1.3) drop-shadow(0 0 10px rgba(255, 215, 0, 0.8));
+  z-index: 101;
 }
 
 /* Active portrait spins in place */


### PR DESCRIPTION
ISSUE 1: Chakra Holder Visualization
PROBLEM:
- Chakra segments showed raw chakra count (0-10) without context
- No visual indication of jutsu (4) vs ultimate (8) thresholds
- Didn't proportionally fill based on character's actual chakra costs
- All segments looked identical, making it hard to see progress

SOLUTION:
- Calculate proportional fill based on ultimate cost (e.g., 4/8 = 50%)
- Show segments proportionally: (currentChakra / ultimateCost) * 10 segments
- Add visual distinction between jutsu range and ultimate range segments
  - Jutsu range (0-50%): Slightly brighter with blue-ish tint
  - Ultimate range (50-100%): Much brighter with saturated colors
- Now clearly shows "how close am I to my next attack?"

ISSUE 2: Character Switching (Bench <-> Active)
PROBLEM:
- Unit flags (isActive, isBench) not properly updated during switch
- Chakra wheels not properly transferred between active/bench states
- Battlefield rendering not synchronized with team holder
- Speed gauge not reset for incoming unit

SOLUTION:
- Properly update isActive/isBench flags BEFORE swapping
- Reset speed gauge to 0 for incoming unit (fair turn order)
- Update combatants list so battlefield reflects the swap
- Remove and recreate chakra wheels with proper context
- Synchronize battlefield, speed gauge, and team holder rendering
- Enhanced visual feedback with brightness and glow effects during switch

FILES MODIFIED:
- js/battle/battle-chakra-wheel.js: Proportional fill calculation
- css/battle-chakra-wheel.css: Jutsu/ultimate range styling
- js/battle/battle-team-holder.js: Improved switch logic
- css/battle-team-holder.css: Enhanced switch animation feedback