### PR TITLE
Remove intro splash from login and village

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
   <link rel="stylesheet" href="css/ui-layout.css?v=2" />
   <link rel="stylesheet" href="css/settings-modal.css?v=2" />
   <link rel="stylesheet" href="css/modal-system.css?v=1" />
-  <link rel="stylesheet" href="css/intro-screen.css" />
+  <link rel="stylesheet" href="css/login-overlay.css" />
+  <link rel="stylesheet" href="css/loading-bridge.css" />
   <!-- Hide scrollbar but keep functionality -->
   <style>
     body,
@@ -38,36 +39,6 @@
       gap: 12px;
       text-align: center;
     }
-  </style>
-</head>
-
-<body>
-  <!-- Intro Screen (Tap to Start) -->
-  <div id="intro-screen" class="intro-screen" role="button" aria-label="Tap to start the game">
-    <div class="intro-content">
-      <h1 class="intro-title">Blazing Awakening</h1>
-      <p class="intro-subtitle">Tap to begin your ninja journey and enter the village plaza.</p>
-      <div class="tap-to-start" data-tap-start>
-        <img src="assets/ui/tap%20to%20start%20asset.png" alt="Tap to start" />
-      </div>
-    </div>
-  </div>
-
-  <!-- 16:9 Game Canvas Wrapper -->
-  <div class="game-canvas-wrapper">
-    <div class="game-canvas">
-      <div class="game-content">
-        <!-- Default background -->
-        <div id="full-bg" class="bg-1"></div>
-
-        <!-- Character Vignette Display -->
-        <div class="character-vignette-container"></div>
-
-        <!-- Vignette Edge Fading Effect -->
-        <div class="vignette-overlay"></div>
-
-        <!-- Wind Animation Particles -->
-        <div class="wind-container"></div>
 
     .login-landing__badge {
       display: inline-flex;
@@ -102,18 +73,8 @@
     }
   </style>
 </head>
-<body>
-  <!-- Intro Screen (Tap to Start) -->
-  <div id="intro-screen" class="intro-screen" role="button" aria-label="Tap to start the game">
-    <div class="intro-content">
-      <h1 class="intro-title">Blazing Awakening</h1>
-      <p class="intro-subtitle">Tap to begin your ninja journey and enter the village plaza.</p>
-      <div class="tap-to-start" data-tap-start>
-        <img src="assets/ui/tap%20to%20start%20asset.png" alt="Tap to start" />
-      </div>
-    </div>
-  </div>
 
+<body>
   <section class="login-landing" aria-hidden="true">
     <div class="login-landing__badge">Village Gate</div>
     <h1 class="login-landing__headline">Sign in to enter the Village HUD</h1>
@@ -160,8 +121,20 @@
     </div>
   </div>
 
+  <!-- 16:9 Game Canvas Wrapper (background + effects) -->
+  <div class="game-canvas-wrapper">
+    <div class="game-canvas">
+      <div class="game-content">
+        <div id="full-bg" class="bg-1"></div>
+        <div class="character-vignette-container"></div>
+        <div class="vignette-overlay"></div>
+        <div class="wind-container"></div>
+      </div>
+    </div>
+  </div>
+
   <!-- Scripts -->
-  <script src="js/intro-screen.js"></script>
+  <script src="js/login-overlay.js"></script>
   <!-- Core Libraries -->
   <script src="https://cdn.jsdelivr.net/npm/howler@2.2.4/dist/howler.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8/hammer.min.js"></script>
@@ -358,7 +331,6 @@
       }
 
       // ===== RIGHT BANNER PANEL NAVIGATION =====
-
       const bannerButtons = document.querySelectorAll('.right-banner-panel .banner-button');
       bannerButtons.forEach(button => {
         button.addEventListener('click', () => {
@@ -557,9 +529,11 @@
           alert(muted ? "🔇 SFX MUTED" : "🔊 SFX UNMUTED");
           showAudioSettings();
         } else if (choice === "7") {
-          if (window.ModalManager) { window.ModalManager.showConfirm("Reset all audio settings to defaults?", () => {
-            window.AudioManager.reset();
-            if (window.ModalManager) { window.ModalManager.showInfo("✅ Audio settings reset to defaults"); }
+          if (window.ModalManager) {
+            window.ModalManager.showConfirm("Reset all audio settings to defaults?", () => {
+              window.AudioManager.reset();
+              if (window.ModalManager) { window.ModalManager.showInfo("✅ Audio settings reset to defaults"); }
+            });
           }
           showAudioSettings();
         } else if (choice === "8") {
@@ -602,9 +576,5 @@
       console.log("✅ All systems initialized!");
     });
   </script>
-
-      </div><!-- .game-content -->
-    </div><!-- .game-canvas -->
-  </div><!-- .game-canvas-wrapper -->
 </body>
 </html>

--- a/js/login-overlay.js
+++ b/js/login-overlay.js
@@ -6,6 +6,8 @@
   const form = formWrapper?.querySelector('form');
   const usernameInput = overlay?.querySelector('[data-login-username]');
   const guestButton = overlay?.querySelector('[data-login-guest]');
+  const loadingBridge = document.getElementById('login-loading');
+  const redirectUrl = overlay?.dataset.redirect;
   const usernameDisplay = document.getElementById('username-display');
 
   if (!overlay) return;
@@ -45,6 +47,18 @@
     const removeOverlay = () => overlay.remove();
     overlay.addEventListener('transitionend', removeOverlay, { once: true });
     setTimeout(removeOverlay, 650);
+
+    if (loadingBridge && redirectUrl) {
+      loadingBridge.classList.remove('is-hidden');
+      const loaderText = loadingBridge.querySelector('[data-loading-message]');
+      if (loaderText) {
+        loaderText.textContent = 'Entering the village plaza…';
+      }
+
+      setTimeout(() => {
+        window.location.href = redirectUrl;
+      }, 550);
+    }
   };
 
   if (hasLoggedIn()) {

--- a/village.html
+++ b/village.html
@@ -16,7 +16,6 @@
   <link rel="stylesheet" href="css/ui-layout.css?v=2" />
   <link rel="stylesheet" href="css/settings-modal.css?v=2" />
   <link rel="stylesheet" href="css/modal-system.css?v=1" />
-  <link rel="stylesheet" href="css/intro-screen.css" />
   <!-- Hide scrollbar but keep functionality -->
   <style>
     /* Hide scrollbar for Chrome, Safari and Opera */
@@ -35,17 +34,6 @@
 </head>
 
 <body>
-  <!-- Intro Screen (Tap to Start) -->
-  <div id="intro-screen" class="intro-screen" role="button" aria-label="Tap to start the game">
-    <div class="intro-content">
-      <h1 class="intro-title">Blazing Awakening</h1>
-      <p class="intro-subtitle">Tap to begin your ninja journey and enter the village plaza.</p>
-      <div class="tap-to-start" data-tap-start>
-        <img src="assets/ui/tap%20to%20start%20asset.png" alt="Tap to start" />
-      </div>
-    </div>
-  </div>
-
   <!-- 16:9 Game Canvas Wrapper -->
   <div class="game-canvas-wrapper">
     <div class="game-canvas">
@@ -203,7 +191,6 @@
   </div>
 
   <!-- Scripts -->
-  <script src="js/intro-screen.js"></script>
   <!-- Core Libraries -->
   <script src="https://cdn.jsdelivr.net/npm/howler@2.2.4/dist/howler.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8/hammer.min.js"></script>


### PR DESCRIPTION
## Summary
- remove the intro splash overlay from the login and village pages so users land directly on the login/village content
- drop related stylesheet and script references to prevent the Blazing Awakening screen from reappearing when navigating back

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c2e8639608325ae93c2c0ed26201b)