### PR TITLE
Fix login overlay redirect when already signed in

### DIFF
--- a/js/login-overlay.js
+++ b/js/login-overlay.js
@@ -6,6 +6,7 @@
   const form = formWrapper?.querySelector('form');
   const usernameInput = overlay?.querySelector('[data-login-username]');
   const guestButton = overlay?.querySelector('[data-login-guest]');
+  const fastEnterButton = overlay?.querySelector('[data-login-fast]');
   const loadingBridge = document.getElementById('login-loading');
   const redirectUrl = overlay?.dataset.redirect;
   const usernameDisplay = document.getElementById('username-display');
@@ -64,6 +65,23 @@
   if (hasLoggedIn()) {
     const storedName = safeGet(USERNAME_KEY);
     if (storedName) setUsername(storedName);
+
+    if (loadingBridge && redirectUrl) {
+      overlay.classList.add('is-hidden');
+      document.body.classList.remove('login-active');
+      loadingBridge.classList.remove('is-hidden');
+
+      const loaderText = loadingBridge.querySelector('[data-loading-message]');
+      if (loaderText) {
+        loaderText.textContent = 'Resuming your village session…';
+      }
+
+      setTimeout(() => {
+        window.location.href = redirectUrl;
+      }, 450);
+      return;
+    }
+
     overlay.remove();
     document.body.classList.remove('login-active');
     return;


### PR DESCRIPTION
## Summary
- bind the fast enter button to prevent runtime errors on the login overlay
- show the loading bridge and redirect automatically when a saved login is detected

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c4cd1ef908325b3e6f86ee7656fa2)