### PR TITLE
Add ninja rosters to login accounts

### DIFF
--- a/css/login-overlay.css
+++ b/css/login-overlay.css
@@ -15,6 +15,7 @@
   align-items: center;
   justify-content: center;
   padding: clamp(16px, 4vw, 32px);
+  overflow: hidden;
   background:
     linear-gradient(160deg, rgba(10, 12, 18, 0.85), rgba(10, 12, 18, 0.65)),
     url('../assets/Main Background/login background.png') center/cover no-repeat;
@@ -45,6 +46,8 @@ body.login-active {
   background: linear-gradient(135deg, rgba(20, 24, 33, 0.92), rgba(14, 16, 24, 0.92));
   box-shadow: 0 24px 70px rgba(0, 0, 0, 0.5), 0 0 22px rgba(255, 210, 138, 0.28);
   overflow: hidden;
+  position: relative;
+  z-index: 1;
 }
 
 .login-hero {
@@ -151,6 +154,7 @@ body.login-active {
   color: #fff;
   outline: none;
   transition: border-color 0.25s ease, box-shadow 0.25s ease;
+  box-sizing: border-box;
 }
 
 .login-form input:focus {
@@ -167,6 +171,90 @@ body.login-active {
   cursor: pointer;
   border: none;
   transition: transform 0.2s ease, box-shadow 0.25s ease, background 0.25s ease;
+  box-sizing: border-box;
+}
+
+.login-overlay::before,
+.login-overlay::after {
+  content: "";
+  position: absolute;
+  inset: -12%;
+  pointer-events: none;
+  background:
+    linear-gradient(
+      115deg,
+      rgba(255, 255, 255, 0) 0%,
+      rgba(255, 255, 255, 0.07) 7%,
+      rgba(255, 255, 255, 0.02) 16%,
+      rgba(255, 255, 255, 0) 25%
+    ),
+    linear-gradient(
+      125deg,
+      rgba(118, 183, 255, 0) 0%,
+      rgba(118, 183, 255, 0.18) 8%,
+      rgba(118, 183, 255, 0.04) 22%,
+      rgba(118, 183, 255, 0) 32%
+    ),
+    radial-gradient(circle at 30% 20%, rgba(255, 210, 138, 0.12), transparent 46%),
+    radial-gradient(circle at 78% 68%, rgba(118, 183, 255, 0.09), transparent 50%);
+  background-size: 260% 260%, 200% 200%, 120% 120%, 120% 120%;
+  background-repeat: repeat;
+  filter: blur(0.5px);
+  mix-blend-mode: screen;
+  opacity: 0.6;
+}
+
+.login-overlay::before {
+  animation: wind-flow 24s linear infinite;
+}
+
+.login-overlay::after {
+  animation: wind-drift 28s linear infinite reverse, wind-shimmer 18s ease-in-out infinite;
+  opacity: 0.38;
+}
+
+@keyframes wind-flow {
+  from {
+    background-position: 0% 45%, 12% 0%, 20% 18%, 60% 60%;
+    transform: translate3d(-6%, -4%, 0);
+  }
+
+  50% {
+    background-position: 120% 40%, -18% 46%, 46% 40%, 90% 48%;
+  }
+
+  to {
+    background-position: 240% 42%, -48% 88%, 96% 22%, 130% 36%;
+    transform: translate3d(8%, 6%, 0);
+  }
+}
+
+@keyframes wind-drift {
+  from {
+    transform: translate3d(-10%, -8%, 0) skewX(-1deg);
+  }
+
+  50% {
+    transform: translate3d(2%, 2%, 0) skewX(0deg);
+  }
+
+  to {
+    transform: translate3d(10%, 12%, 0) skewX(1deg);
+  }
+}
+
+@keyframes wind-shimmer {
+  from {
+    opacity: 0.32;
+  }
+
+  35% {
+    opacity: 0.48;
+  }
+
+  to {
+    opacity: 0.32;
+  }
 }
 
 .login-primary {
@@ -191,11 +279,49 @@ body.login-active {
   transform: translateY(-1px);
 }
 
+.login-create {
+  background: linear-gradient(135deg, rgba(118, 183, 255, 0.22), rgba(255, 210, 138, 0.2));
+  color: #e8f1ff;
+  border: 1px solid rgba(118, 183, 255, 0.35);
+}
+
+.login-create:hover {
+  background: linear-gradient(135deg, rgba(118, 183, 255, 0.3), rgba(255, 210, 138, 0.26));
+  transform: translateY(-1px);
+}
+
 .login-note {
   margin: 6px 0 0;
   font-size: 0.85rem;
   color: #d8d8d8;
   line-height: 1.4;
+}
+
+.login-feedback {
+  margin: 6px 0 0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.05);
+  display: none;
+}
+
+.login-feedback.is-visible {
+  display: block;
+}
+
+.login-feedback.is-error {
+  border-color: rgba(255, 115, 115, 0.6);
+  background: linear-gradient(135deg, rgba(255, 115, 115, 0.14), rgba(255, 71, 71, 0.08));
+  color: #ffecec;
+}
+
+.login-feedback.is-success {
+  border-color: rgba(118, 183, 255, 0.55);
+  background: linear-gradient(135deg, rgba(118, 183, 255, 0.15), rgba(255, 210, 138, 0.08));
+  color: #eaf3ff;
 }
 
 

--- a/data/user-accounts.json
+++ b/data/user-accounts.json
@@ -1,0 +1,23 @@
+{
+  "nextId": 1010,
+  "accounts": [
+    {
+      "id": 1001,
+      "username": "naruto",
+      "password": "shadowclone",
+      "ninjas": [
+        { "id": 1, "name": "Naruto Uzumaki", "rank": "Genin", "level": 5, "element": "Wind" },
+        { "id": 2, "name": "Jiraiya", "rank": "Sannin", "level": 12, "element": "Toad" }
+      ]
+    },
+    {
+      "id": 1002,
+      "username": "sakura",
+      "password": "medical",
+      "ninjas": [
+        { "id": 1, "name": "Sakura Haruno", "rank": "Genin", "level": 6, "element": "Earth" },
+        { "id": 2, "name": "Tsunade", "rank": "Sannin", "level": 15, "element": "Earth" }
+      ]
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -53,12 +53,14 @@
           <input id="login-username" data-login-username type="text" name="username" maxlength="20" placeholder="Enter your ninja name" autocomplete="username" required />
 
           <label class="login-label" for="login-password">Password</label>
-          <input id="login-password" type="password" name="password" maxlength="32" placeholder="••••••••" autocomplete="current-password" required />
+          <input id="login-password" data-login-password type="password" name="password" maxlength="32" placeholder="••••••••" autocomplete="current-password" required />
 
           <button type="submit" class="login-primary">Log In</button>
+          <button type="button" class="login-create" data-login-create>Create Account</button>
           <button type="button" class="login-secondary" data-login-guest>Continue as guest</button>
 
-          <p class="login-note">Your session is remembered locally so returning to the Village HUD won't prompt you again.</p>
+          <div class="login-feedback" data-login-feedback aria-live="polite"></div>
+          <p class="login-note">Your session and new accounts are remembered locally so returning to the Village HUD won't prompt you again.</p>
         </form>
       </div>
     </div>

--- a/js/login-overlay.js
+++ b/js/login-overlay.js
@@ -1,11 +1,19 @@
 (function () {
   const LOGIN_KEY = 'blazing-login-complete';
   const USERNAME_KEY = 'blazing-login-username';
+  const PLAYER_ID_KEY = 'blazing-player-id';
+  const ACCOUNT_STORE_KEY = 'blazing-account-store';
+  const ACCOUNT_SOURCE_PATH = 'data/user-accounts.json';
+
   const overlay = document.getElementById('login-overlay');
   const formWrapper = overlay?.querySelector('[data-login-form]');
   const form = formWrapper?.querySelector('form');
   const usernameInput = overlay?.querySelector('[data-login-username]');
+  const passwordInput = overlay?.querySelector('[data-login-password]');
   const guestButton = overlay?.querySelector('[data-login-guest]');
+  const fastEnterButton = overlay?.querySelector('[data-login-fast]');
+  const createAccountButton = overlay?.querySelector('[data-login-create]');
+  const feedback = overlay?.querySelector('[data-login-feedback]');
   const loadingBridge = document.getElementById('login-loading');
   const redirectUrl = overlay?.dataset.redirect;
   const usernameDisplay = document.getElementById('username-display');
@@ -28,7 +36,104 @@
     }
   };
 
+  let accountStore = { nextId: 1001, accounts: [] };
+
+  const normalizeNinjas = (ninjas = []) => {
+    if (!Array.isArray(ninjas)) return [];
+    return ninjas
+      .filter((ninja) => ninja?.name)
+      .map((ninja, index) => ({
+        id: Number(ninja.id) || index + 1,
+        name: String(ninja.name),
+        level: Number(ninja.level) || 1,
+        rank: String(ninja.rank || 'Genin'),
+        element: String(ninja.element || 'Neutral'),
+      }));
+  };
+
+  const normalizeAccountStore = (store) => {
+    const normalized = {
+      nextId: Number(store?.nextId) || 1001,
+      accounts: Array.isArray(store?.accounts)
+        ? store.accounts
+            .filter((account) => account?.username && account?.password)
+            .map((account) => ({
+              id: Number(account.id) || null,
+              username: String(account.username),
+              password: String(account.password),
+              ninjas: normalizeNinjas(account.ninjas),
+            }))
+        : [],
+    };
+
+    if (!normalized.nextId && normalized.accounts.length) {
+      const maxId = normalized.accounts.reduce(
+        (max, account) => Math.max(max, Number(account.id) || 0),
+        0,
+      );
+      normalized.nextId = Math.max(1001, maxId + 1);
+    }
+
+    return normalized;
+  };
+
+  const persistAccountStore = () => {
+    try {
+      safeSet(ACCOUNT_STORE_KEY, JSON.stringify(accountStore));
+    } catch (error) {
+      // Ignore persistence errors; session login still continues.
+    }
+  };
+
+  const loadAccountStore = async () => {
+    const cached = safeGet(ACCOUNT_STORE_KEY);
+    if (cached) {
+      try {
+        accountStore = normalizeAccountStore(JSON.parse(cached));
+        return accountStore;
+      } catch (error) {
+        // Fall through to fetch a clean copy.
+      }
+    }
+
+    try {
+      const response = await fetch(ACCOUNT_SOURCE_PATH);
+      if (response.ok) {
+        const remoteStore = await response.json();
+        accountStore = normalizeAccountStore(remoteStore);
+        persistAccountStore();
+        return accountStore;
+      }
+    } catch (error) {
+      // Fall back to an empty store.
+    }
+
+    accountStore = { nextId: 1001, accounts: [] };
+    persistAccountStore();
+    return accountStore;
+  };
+
+  const accountStoreReady = loadAccountStore();
+
   const hasLoggedIn = () => safeGet(LOGIN_KEY) === 'true';
+
+  const attachMissingNinjas = (account) => {
+    if (!account) return account;
+    if (!Array.isArray(account.ninjas) || account.ninjas.length === 0) {
+      const fallback = starterNinjas(account.id || nextPlayerId());
+      account.ninjas = fallback;
+      persistAccountStore();
+    }
+    return account;
+  };
+
+  const showFeedback = (message, isError = false) => {
+    if (!feedback) return;
+    feedback.textContent = message;
+    feedback.classList.toggle('is-error', Boolean(isError));
+    feedback.classList.toggle('is-success', !isError);
+    feedback.classList.add('is-visible');
+  };
 
   const setUsername = (name) => {
     if (!name) return;
@@ -38,9 +143,37 @@
     }
   };
 
-  const finalizeLogin = (name) => {
+  const setPlayerId = (playerId) => {
+    if (playerId) {
+      safeSet(PLAYER_ID_KEY, String(playerId));
+    }
+  };
+
+  const findAccount = (name) => {
+    const target = name?.trim().toLowerCase();
+    if (!target) return null;
+    return accountStore.accounts.find(
+      (account) => account.username?.toLowerCase() === target,
+    );
+  };
+
+  const nextPlayerId = () => {
+    const highestId = accountStore.accounts.reduce(
+      (max, account) => Math.max(max, Number(account.id) || 0),
+      0,
+    );
+    const startingId = Number(accountStore.nextId) || 1001;
+    const newId = Math.max(startingId, highestId + 1);
+    accountStore.nextId = newId + 1;
+    return newId;
+  };
+
+  const finalizeLogin = (name, account = null) => {
     const resolvedName = name?.trim() || safeGet(USERNAME_KEY) || 'Ninja';
     setUsername(resolvedName);
+    if (account?.id) {
+      setPlayerId(account.id);
+    }
     safeSet(LOGIN_KEY, 'true');
     overlay.classList.add('is-hidden');
     document.body.classList.remove('login-active');
@@ -64,6 +197,23 @@
   if (hasLoggedIn()) {
     const storedName = safeGet(USERNAME_KEY);
     if (storedName) setUsername(storedName);
+
+    if (loadingBridge && redirectUrl) {
+      overlay.classList.add('is-hidden');
+      document.body.classList.remove('login-active');
+      loadingBridge.classList.remove('is-hidden');
+
+      const loaderText = loadingBridge.querySelector('[data-loading-message]');
+      if (loaderText) {
+        loaderText.textContent = 'Resuming your village session…';
+      }
+
+      setTimeout(() => {
+        window.location.href = redirectUrl;
+      }, 450);
+      return;
+    }
+
     overlay.remove();
     document.body.classList.remove('login-active');
     return;
@@ -76,14 +226,100 @@
     usernameInput.value = storedName;
   }
 
-  form?.addEventListener('submit', (event) => {
+  const starterNinjas = (playerId) => {
+    const starters = [
+      { name: 'Naruto Uzumaki', element: 'Wind' },
+      { name: 'Sasuke Uchiha', element: 'Lightning' },
+      { name: 'Sakura Haruno', element: 'Earth' },
+      { name: 'Rock Lee', element: 'Taijutsu' },
+      { name: 'Shikamaru Nara', element: 'Shadow' },
+      { name: 'Hinata Hyuga', element: 'Water' },
+    ];
+
+    const offset = Number(playerId) % starters.length;
+    const picks = [starters[offset], starters[(offset + 2) % starters.length]];
+
+    return picks.map((ninja, index) => ({
+      id: index + 1,
+      name: ninja.name,
+      level: 1,
+      rank: 'Genin',
+      element: ninja.element,
+    }));
+  };
+
+  form?.addEventListener('submit', async (event) => {
     event.preventDefault();
-    const username = usernameInput?.value || '';
-    finalizeLogin(username);
+    const username = usernameInput?.value?.trim?.() || '';
+    const password = passwordInput?.value || '';
+
+    await accountStoreReady;
+
+    if (!username || !password) {
+      showFeedback('Enter a username and password to log in.', true);
+      return;
+    }
+
+    const account = attachMissingNinjas(findAccount(username));
+    if (!account) {
+      showFeedback('No account found. Try creating one first.', true);
+      return;
+    }
+
+    if (account.password !== password) {
+      showFeedback('Incorrect password. Please try again.', true);
+      return;
+    }
+
+    showFeedback('Welcome back! Taking you to the village…');
+    finalizeLogin(account.username, account);
+  });
+
+  createAccountButton?.addEventListener('click', async (event) => {
+    event.preventDefault();
+    const username = usernameInput?.value?.trim?.() || '';
+    const password = passwordInput?.value || '';
+
+    await accountStoreReady;
+
+    if (!username || !password) {
+      showFeedback('Choose a username and password to create your account.', true);
+      return;
+    }
+
+    if (username.length < 3) {
+      showFeedback('Usernames need at least 3 characters.', true);
+      return;
+    }
+
+    if (password.length < 4) {
+      showFeedback('Passwords need at least 4 characters.', true);
+      return;
+    }
+
+    const existingAccount = findAccount(username);
+    if (existingAccount) {
+      showFeedback('That ninja already exists. Try logging in instead.', true);
+      return;
+    }
+
+    const playerId = nextPlayerId();
+    const newAccount = {
+      id: playerId,
+      username,
+      password,
+      ninjas: starterNinjas(playerId),
+    };
+    accountStore.accounts.push(newAccount);
+    persistAccountStore();
+
+    showFeedback(`Account created! Player ID #${playerId}. Signing you in…`);
+    finalizeLogin(username, newAccount);
   });
 
   guestButton?.addEventListener('click', (event) => {
     event.preventDefault();
+    showFeedback('Continuing as guest.');
     finalizeLogin(usernameInput?.value || storedName || '');
   });
 


### PR DESCRIPTION
## Summary
- normalize stored accounts to include ninja roster details
- seed sample accounts with distinct ninja lineups and generate starters for new sign-ups
- ensure missing rosters are auto-filled so logins retain player character data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c4cd1ef908325b3e6f86ee7656fa2)