### PR TITLE
Add placeholder tools page

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Blazing — Tools</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="css/bottombar.css" />
+  <link rel="stylesheet" href="css/settings-modal.css" />
+  <style>
+    @import url("https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600&display=swap");
+
+    :root {
+      --gold: #d9b362;
+      --ink: #0b0b0f;
+      --card: rgba(20, 20, 24, 0.65);
+      --border: rgba(255, 215, 120, 0.2);
+    }
+
+    body {
+      margin: 0;
+      padding: 20px;
+      padding-bottom: 120px;
+      min-height: 100vh;
+      font-family: "Cinzel", "Times New Roman", serif;
+      background: linear-gradient(180deg, #0f0e14 0%, #181822 100%);
+      color: #eee6d1;
+    }
+
+    .page-title {
+      text-align: center;
+      font-size: 36px;
+      font-weight: 600;
+      color: var(--gold);
+      margin: 10px 0 8px;
+      letter-spacing: 1px;
+    }
+
+    .page-subtitle {
+      text-align: center;
+      margin: 0 0 28px;
+      color: #b8b3a3;
+      font-size: 14px;
+      letter-spacing: 0.5px;
+    }
+
+    .tools-grid {
+      max-width: 960px;
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 16px;
+    }
+
+    .tool-card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 18px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+    }
+
+    .tool-title {
+      font-size: 18px;
+      font-weight: 600;
+      color: var(--gold);
+      margin: 0 0 8px;
+    }
+
+    .tool-desc {
+      margin: 0;
+      font-size: 13px;
+      color: #c7c1ae;
+      line-height: 1.4;
+    }
+
+    .coming-soon {
+      text-align: center;
+      margin: 32px 0 12px;
+      color: #b362d9;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+    }
+
+    .back-button {
+      padding: 12px 24px;
+      font-family: "Cinzel", serif;
+      font-size: 16px;
+      font-weight: 600;
+      color: #fff;
+      background: linear-gradient(180deg, #d9b362 0%, #a7822c 100%);
+      border: 1px solid rgba(217, 179, 98, 0.4);
+      border-radius: 8px;
+      cursor: pointer;
+      transition: all .2s ease;
+      display: block;
+      margin: 30px auto 0;
+      text-decoration: none;
+      text-align: center;
+      width: fit-content;
+    }
+
+    .back-button:hover {
+      background: linear-gradient(180deg, #e6c47e 0%, #b89642 100%);
+      transform: translateY(-1px);
+    }
+  </style>
+  <!-- Hide scrollbar but keep functionality -->
+  <style>
+    body::-webkit-scrollbar,
+    html::-webkit-scrollbar,
+    *::-webkit-scrollbar {
+      display: none;
+    }
+
+    body, html, * {
+      -ms-overflow-style: none;
+      scrollbar-width: none;
+    }
+  </style>
+</head>
+<body class="page-tools">
+  <main class="tools-content">
+    <h1 class="page-title">Tools & Utilities</h1>
+    <p class="page-subtitle">Quick access to debugging helpers and upcoming management utilities.</p>
+
+    <div class="tools-grid">
+      <div class="tool-card">
+        <div class="tool-title">Benchmarks & Debug</div>
+        <p class="tool-desc">Access the chakra benchmark and other performance helpers to validate battle systems while iterating.</p>
+      </div>
+      <div class="tool-card">
+        <div class="tool-title">Data Maintenance</div>
+        <p class="tool-desc">Centralize scripts and migration helpers for character data, asset cleanups, and other routine upkeep tasks.</p>
+      </div>
+      <div class="tool-card">
+        <div class="tool-title">Coming Soon</div>
+        <p class="tool-desc">This hub will collect developer shortcuts and QA tools. For now, use the navigation below to return to other areas.</p>
+      </div>
+    </div>
+
+    <p class="coming-soon">More utilities will be added here soon.</p>
+    <a href="village.html" class="back-button">Back to Main Menu</a>
+  </main>
+
+  <div class="bottom-bar">
+    <div class="bottom-bar-content">
+      <button class="hud-button" id="btn-village" aria-label="Village">
+        <img src="assets/icons/village_icon.png" alt="Village">
+      </button>
+      <button class="hud-button" id="btn-characters" aria-label="Characters">
+        <img src="assets/icons/characters_icon.png" alt="Characters">
+      </button>
+      <button class="hud-button" id="btn-fusion" aria-label="Fusion">
+        <img src="assets/icons/fusion_icon.png" alt="Fusion">
+      </button>
+      <button class="hud-button" id="btn-teams" aria-label="Teams">
+        <img src="assets/icons/teams_icon.png" alt="Teams">
+      </button>
+      <button class="hud-button" id="btn-tools" aria-label="Tools">
+        <img src="assets/icons/guilds_icon.png" alt="Tools">
+      </button>
+      <button class="hud-button" id="btn-summon" aria-label="Summon">
+        <img src="assets/icons/summon_icon.png" alt="Summon">
+      </button>
+      <button class="hud-button" id="btn-missions" aria-label="Missions">
+        <img src="assets/icons/missions_icon.png" alt="Missions">
+      </button>
+      <button class="hud-button" id="btn-inventory" aria-label="Inventory">
+        <img src="assets/icons/inventory_icon.png" alt="Inventory">
+      </button>
+      <button class="hud-button" id="btn-shop" aria-label="Shop">
+        <img src="assets/icons/shop_icon.png" alt="Shop">
+      </button>
+    </div>
+  </div>
+
+  <script src="js/audio-manager.js"></script>
+  <script src="js/music-player.js"></script>
+  <script src="js/navigation.js"></script>
+  <script src="js/settings-modal.js?v=2"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Tools & Utilities page so navigation links no longer lead to a missing file
- include basic layout and navigation hooks consistent with other pages

## Testing
- not run (static content)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69311d6af2d88325958feb03ae12e3fb)