### PR TITLE
Use CSS gradients for chest visuals

### DIFF
--- a/MISSION_REWARDS_IMPLEMENTATION.md
+++ b/MISSION_REWARDS_IMPLEMENTATION.md
@@ -190,6 +190,11 @@ async function onStageComplete(core) {
 - **Position**: Center of battlefield (50%, 40%)
 - **Animation**: Appears with spin, floats continuously
 
+### Chest Visuals:
+- Closed chest uses a deep gold gradient fill.
+- Opened chest shifts to a brighter gold gradient during the reveal animation.
+- Gradients are pure CSS, so no external images are required.
+
 ### Results Screen:
 - **Background**: Near-black with subtle transparency
 - **Title**: Large gold text with glow

--- a/js/battle/battle-rewards.js
+++ b/js/battle/battle-rewards.js
@@ -77,7 +77,7 @@
         transform: translate(-50%, -50%);
         width: 80px;
         height: 80px;
-        background: linear-gradient(135deg, #8B4513 0%, #D4AF37 50%, #8B4513 100%);
+        background: ${this.getChestBackground('closed')};
         border: 4px solid #FFD700;
         border-radius: 8px;
         box-shadow:
@@ -307,7 +307,7 @@
         width: 60px;
         height: 60px;
         margin: 0 auto 1rem;
-        background: linear-gradient(135deg, #8B4513, #D4AF37);
+        background: ${this.getChestBackground('closed')};
         border: 3px solid #FFD700;
         border-radius: 6px;
         box-shadow: 0 0 15px rgba(255, 215, 0, 0.6);
@@ -341,6 +341,7 @@
       chestIcon.style.animation = 'chestFlash 0.5s ease-in-out 3';
 
       await this.delay(1500);
+      chestIcon.style.background = this.getChestBackground('open');
       chestIcon.style.opacity = '0.3';
       rewardsList.style.opacity = '1';
 
@@ -375,6 +376,19 @@
       };
 
       return names[itemKey] || itemKey;
+    },
+
+    /**
+     * Build chest background with sprite and gradient fallback
+     */
+    getChestBackground(state = 'closed') {
+      // Use a pure CSS gradient so no binary assets are required. The open state is brighter
+      // to visually indicate the chest has been unlocked during the reveal animation.
+      if (state === 'open') {
+        return 'linear-gradient(135deg, #FFD700 0%, #FFF2AE 45%, #D4AF37 100%)';
+      }
+
+      return 'linear-gradient(135deg, #8B4513 0%, #D4AF37 50%, #8B4513 100%)';
     },
 
     /**


### PR DESCRIPTION
## Summary
- replace mission reward chest sprites with CSS gradients to avoid binary assets
- keep closed/open visuals by toggling between dark and bright gold gradients
- update mission rewards guide to describe the gradient-based chest visuals

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931a5dc66888325bc61da2595e750d8)