### PR TITLE
Fix chakra positioning and character switching issues

### DIFF
--- a/css/battle-chakra-wheel.css
+++ b/css/battle-chakra-wheel.css
@@ -29,10 +29,10 @@
    ========================================= */
 .portrait {
     position: absolute;
-    top: 30px;
-    left: 25px;
-    width: 100px;
-    height: 98px;
+    top: 5px;
+    left: 5px;
+    width: 90px;
+    height: 90px;
     object-fit: cover;
     border-radius: 50%;
     clip-path: circle(50%);
@@ -52,8 +52,8 @@
    ========================================= */
 .chakra-container {
     position: absolute;
-    top: 11px;
-    left: 30px;
+    top: 5px;
+    left: 5px;
     width: 90px;
     height: 90px;
     border-radius: 50%;
@@ -103,8 +103,8 @@
    ========================================= */
 .chakra-frame {
     position: absolute;
-    top: -70px;
-    left: -68px;
+    top: -100px;
+    left: -100px;
     width: 300px !important;
     height: 300px !important;
     pointer-events: none;

--- a/css/battle-team-holder.css
+++ b/css/battle-team-holder.css
@@ -53,6 +53,11 @@
   /* Hover effect handled by unit-ring in battle-chakra-wheel.css */
 }
 
+.active-portrait-container.drag-over {
+  box-shadow: 0 0 20px rgba(212, 175, 55, 0.9);
+  transform: scale(1.05);
+}
+
 /* Portrait styling is handled by .portrait class in battle-chakra-wheel.css */
 
 /* === Bench Portrait Container (Small, staggered nested below active) === */
@@ -68,6 +73,11 @@
     left: 0;
     bottom: -1px;
     z-index: 10;
+    cursor: grab;
+}
+
+.bench-portrait-container:active {
+    cursor: grabbing;
 }
 
 /* Portrait styling is handled by .portrait class in battle-chakra-wheel.css */


### PR DESCRIPTION
This commit addresses two main issues:

1. Chakra positioning:
   - Centered portrait, chakra container, and frame within unit ring
   - Changed portrait from (top: 30px, left: 25px, 100x98px) to (top: 5px, left: 5px, 90x90px)
   - Changed chakra container from (top: 11px, left: 30px) to (top: 5px, left: 5px)
   - Changed frame from (top: -70px, left: -68px) to (top: -100px, left: -100px)
   - All elements now properly concentric for visual alignment

2. Character switching (active ↔ bench):
   - Added draggable="true" to bench portrait containers
   - Implemented drag-and-drop event listeners for bench portraits
   - Added drop zones on active portrait containers
   - Fixed switching logic to transfer battlefield position from active to incoming bench unit
   - Added field/buddy skill updates on swap
   - Added visual feedback (drag-over state, cursor changes)
   - Units no longer disappear when switching - position is properly preserved

Technical changes:
- css/battle-chakra-wheel.css: Updated positioning for proper chakra ring alignment
- css/battle-team-holder.css: Added drag-over styles and cursor feedback
- js/battle/battle-team-holder.js: Implemented full drag-and-drop functionality with position transfer