### PR TITLE
Fix character tab UI sizing and star visibility

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -277,20 +277,20 @@ body.page-characters::-webkit-scrollbar {
 /* ---------- Stars (overlapping nameplate) ---------- */
 .nameplate-stars {
   position: absolute;
-  top: -10px;
+  top: -18px;
   left: 50%;
   transform: translateX(-50%);
   text-align: center;
   z-index: 10;
   display: flex;
-  gap: 2px;
+  gap: 4px;
   justify-content: center;
 }
 .nameplate-stars .star {
-  width: 20px;
-  height: 20px;
+  width: 28px;
+  height: 28px;
   display: inline-block;
-  filter: drop-shadow(0 1px 2px rgba(0,0,0,.6));
+  filter: drop-shadow(0 2px 3px rgba(0,0,0,.8));
 }
 
 /* ---------- Tabs ---------- */
@@ -299,13 +299,15 @@ body.page-characters::-webkit-scrollbar {
   justify-content: center;
   gap: 10px;
   padding: 10px 0;
-  background: rgba(0,0,0,0.3);
+  background: transparent;
 }
 .tab-btn {
   font-family: "Cinzel", serif;
   font-size: 14px;
   color: #cfc2a0;
-  padding: 8px 18px;
+  padding: 12px 27px;
+  min-width: 120px;
+  min-height: 45px;
   border: none;
   background-color: transparent;
   background-image: url('../assets/ui/inactivetab.png');


### PR DESCRIPTION
- Increase tab button size by 50% (12px 27px padding, 120px min-width, 45px min-height)
- Make stars larger (28px) and position higher (-18px) for better nameplate overlap
- Remove dark transparent overlay from tab container background