### PR TITLE
Adjust tab sizing for 900x350 tab images without affecting art

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -305,18 +305,21 @@ body.page-characters::-webkit-scrollbar {
   font-family: "Cinzel", serif;
   font-size: 14px;
   color: #cfc2a0;
-  padding: 12px 27px;
-  min-width: 120px;
-  min-height: 45px;
+  padding: 10px 20px;
+  width: 140px;
+  height: 55px;
   border: none;
   background-color: transparent;
   background-image: url('../assets/ui/inactivetab.png');
-  background-size: contain;
+  background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
   cursor: pointer;
   transition: all .2s ease;
   text-shadow: 0 1px 2px rgba(0,0,0,.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .tab-btn:hover {
   filter: brightness(1.1);
@@ -324,7 +327,7 @@ body.page-characters::-webkit-scrollbar {
 .tab-btn.is-active {
   background-color: transparent;
   background-image: url('../assets/ui/activetab.png');
-  background-size: contain;
+  background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
   color: #fff;


### PR DESCRIPTION
- Set fixed width: 140px, height: 55px (maintains ~2.5:1 aspect ratio)
- Use background-size: 100% 100% to properly scale larger tab images
- Add flexbox centering for proper text alignment
- Reduce padding to prevent text overflow
- Remove min constraints that were affecting modal layout