### PR TITLE
Restore character art to original size

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -686,7 +686,7 @@ body.page-characters::-webkit-scrollbar {
   grid-template-columns: 1fr 1fr;       /* art | info */
   gap: 18px;
   width: min(100%, 1150px);             /* increased from 980px to prevent scrollbar */
-  max-height: 82vh;                     /* stays inside viewport */
+  max-height: 90vh;                     /* increased from 82vh to give more room */
   padding: 16px;
   background-image: url('../assets/ui/infoframe.png');
   background-size: 100% 100%;
@@ -702,10 +702,11 @@ body.page-characters::-webkit-scrollbar {
   overflow: hidden;
   background: #0e0e0f;
   border-radius: 12px;
+  min-height: 500px;                    /* prevent art from collapsing */
 }
 #char-modal-img{
   max-width: 100%;
-  max-height: 60vh;                     /* never pushes controls off screen */
+  max-height: 70vh;                     /* increased from 60vh for larger art */
   object-fit: contain;
   padding: 8px;
 }
@@ -753,10 +754,7 @@ body.page-characters::-webkit-scrollbar {
   }
 }
 
-/* Slightly reduce global art size so tabs sit higher */
-@media (min-width: 901px){
-  #char-modal-img{ max-height: 55vh; }
-}
+/* Art size maintained at 70vh for all screen sizes */
 
 /* ---------- Limit Break Styling ---------- */
 .btn-limitbreak {


### PR DESCRIPTION
- Increase modal max-height from 82vh to 90vh
- Add min-height: 500px to art container to prevent collapse
- Increase image max-height from 60vh to 70vh
- Remove media query that was reducing art size to 55vh on large screens