### PR TITLE
Remove duplicate #char-modal-img rule limiting art size

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -208,13 +208,6 @@ body.page-characters::-webkit-scrollbar {
   overflow: hidden;
   box-shadow: 0 0 40px rgba(0,0,0,0.6);
 }
-#char-modal-img {
-  width: 100%;
-  object-fit: cover;
-  max-height: 380px;
-  display: block;
-  background: #0e0e0e;
-}
 
 /* ---------- Close Button ---------- */
 .char-close-btn {


### PR DESCRIPTION
- Remove old duplicate rule with max-height: 380px
- Keep only the modal panel rule with max-height: 70vh
- This was preventing character art from displaying at proper size