### PR TITLE
Reduce nameplate and stats width by 40%, remove EQUIP and TOOLS tabs

### DIFF
--- a/characters.html
+++ b/characters.html
@@ -58,8 +58,6 @@
           <button class="tab-btn" data-tab="skills">Ninjutsu</button>
           <button class="tab-btn" data-tab="support">F/B Skills</button>
           <button class="tab-btn" data-tab="abilities">Abilities</button>
-          <button class="tab-btn" data-tab="equip">Equip</button>
-          <button class="tab-btn" data-tab="tools">Tools</button>
         </div>
 
         <div class="tab-panels">

--- a/css/characters.css
+++ b/css/characters.css
@@ -244,6 +244,8 @@ body.page-characters::-webkit-scrollbar {
   align-items: center;
   min-height: 80px;
   position: relative;
+  max-width: 60%;
+  margin: 0 auto;
 }
 .nameplate-main {
   display: flex;
@@ -357,9 +359,11 @@ body.page-characters::-webkit-scrollbar {
 /* ---------- Stats Grid ---------- */
 .stats-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit,minmax(160px,1fr));
+  grid-template-columns: repeat(auto-fit,minmax(96px,1fr));
   gap: 8px;
   padding: 8px 0 12px;
+  max-width: 60%;
+  margin: 0 auto;
 }
 .stat-row {
   display: flex;


### PR DESCRIPTION
- Remove EQUIP and TOOLS tab buttons (will be readded later)
- Add max-width: 60% to nameplate to reduce width by 40%
- Reduce stats grid minmax from 160px to 96px (40% reduction)
- Add max-width: 60% to stats grid container
- Center both elements with margin: 0 auto
- This gives more space for character art display