### PR TITLE
Increase nameplate width from 60% to 80% for better text fit

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -244,7 +244,7 @@ body.page-characters::-webkit-scrollbar {
   align-items: center;
   min-height: 80px;
   position: relative;
-  max-width: 60%;
+  max-width: 80%;
   margin: 0 auto;
 }
 .nameplate-main {


### PR DESCRIPTION
- Change max-width from 60% to 80% to comfortably fit character names
- Ensures text isn't cramped while still being more compact than original