### PR TITLE
Fix power grade system and enhance display

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -397,8 +397,8 @@ body.page-characters::-webkit-scrollbar {
 /* Power Holder Display */
 .power-holder-container {
   position: relative;
-  width: 280px;
-  height: 80px;
+  width: 400px;
+  height: 120px;
   margin: 20px auto 0;
   background-image: url('../assets/icons/powerholder.png');
   background-size: contain;
@@ -407,29 +407,40 @@ body.page-characters::-webkit-scrollbar {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 10px 20px;
+  padding: 15px 30px;
 }
 .power-holder-content {
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 0 30px;
+  padding: 0 40px;
 }
 .power-grade {
-  font-family: "Cinzel", serif;
-  font-size: 32px;
-  font-weight: 900;
-  color: #ffd700;
-  text-shadow: 0 0 10px rgba(255, 215, 0, 0.8), 0 2px 4px rgba(0,0,0,0.9);
-  letter-spacing: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 80px;
+}
+.power-grade-img {
+  height: 70px;
+  width: auto;
+  object-fit: contain;
+  filter: drop-shadow(0 0 8px rgba(255, 215, 0, 0.6));
+}
+.power-grade-video {
+  height: 70px;
+  width: auto;
+  object-fit: contain;
+  filter: drop-shadow(0 0 12px rgba(255, 215, 0, 0.8));
 }
 .power-value {
   font-family: "Cinzel", serif;
-  font-size: 20px;
+  font-size: 26px;
   font-weight: 700;
   color: #ffffff;
   text-shadow: 0 2px 4px rgba(0,0,0,0.9);
+  letter-spacing: 1px;
 }
 
 /* ---------- Level / Growth Section ---------- */

--- a/js/characters.js
+++ b/js/characters.js
@@ -88,19 +88,36 @@
     const abilityBonus = unlockedAbilities * 30000;
     const totalPower = power + abilityBonus;
 
-    // Grade thresholds
+    // Grade thresholds (checking from highest to lowest)
     if (totalPower >= 400000) return 'LR';
     if (totalPower >= 300000) return 'UR';
     if (totalPower >= 250000) return 'SSS';
     if (totalPower >= 200000) return 'SS';
     if (totalPower >= 150000) return 'S';
-    if (totalPower >= 100000) return 'A';
-    if (totalPower >= 90000) return 'B';
-    if (totalPower >= 70000) return 'C';
-    if (totalPower >= 50000) return 'D';
-    return 'D';
+    if (totalPower >= 90000) return 'A';
+    if (totalPower >= 70000) return 'B';
+    if (totalPower >= 50000) return 'C';
+    return 'D'; // < 50,000
   }
   window.calculatePowerGrade = calculatePowerGrade;
+
+  /* ---------- Power Grade Display Element ---------- */
+  function getPowerGradeElement(grade) {
+    const gradeLower = grade.toLowerCase();
+
+    // Use video for LR and UR (if available)
+    if (grade === 'LR' || grade === 'UR') {
+      return `
+        <video class="power-grade-video" autoplay loop muted playsinline>
+          <source src="assets/icons/pow_${gradeLower}.mp4" type="video/mp4">
+          <img src="assets/icons/pow_${gradeLower}.png" alt="${grade}" onerror="this.style.display='none';" />
+        </video>`;
+    }
+
+    // Use PNG for other grades
+    return `<img class="power-grade-img" src="assets/icons/pow_${gradeLower}.png" alt="${grade}" onerror="this.innerHTML='${grade}';" />`;
+  }
+  window.getPowerGradeElement = getPowerGradeElement;
 
   /* ---------- Tier helpers ---------- */
   const STAR_COUNT_BY_TIER = { "3S":3,"4S":4,"5S":5,"6S":6,"6SB":6,"7S":7,"7SL":7,"8S":8,"8SM":8,"9S":9,"9ST":9,"10SO":10 };
@@ -380,7 +397,7 @@
         </div>
         <div class="power-holder-container">
           <div class="power-holder-content">
-            <div class="power-grade">${powerGrade}</div>
+            <div class="power-grade">${getPowerGradeElement(powerGrade)}</div>
             <div class="power-value">${totalPower.toLocaleString()}</div>
           </div>
         </div>`;
@@ -426,7 +443,7 @@
         </div>
         <div class="power-holder-container">
           <div class="power-holder-content">
-            <div class="power-grade">${powerGrade}</div>
+            <div class="power-grade">${getPowerGradeElement(powerGrade)}</div>
             <div class="power-value">${totalPower.toLocaleString()}</div>
           </div>
         </div>`;


### PR DESCRIPTION
Critical Fixes:
- Fixed power grade calculation: 50K+ now correctly shows C rank (was D)
- Removed incorrect 100K threshold, now: D<50K, C≥50K, B≥70K, A≥90K, S≥150K
- Ability bonuses now properly included in grade calculation

Visual Enhancements:
- Power grades now display as PNG images (pow_d.png, pow_c.png, etc.)
- LR and UR grades support video (pow_lr.mp4, pow_ur.mp4) with PNG fallback
- Increased power holder size: 280px→400px width, 80px→120px height
- Larger power value text: 20px→26px
- Power grade images: 70px height with glow effects