### PR TITLE
Fix stat display and reposition power holder under character art

### DIFF
--- a/characters.html
+++ b/characters.html
@@ -42,6 +42,7 @@
     <div class="char-modal-panel">
       <div class="char-modal-art">
         <img id="char-modal-img" src="" alt="Character full art" />
+        <div id="char-power-holder-container"></div>
       </div>
       <div class="char-modal-info">
         <div class="nameplate">

--- a/css/characters.css
+++ b/css/characters.css
@@ -360,39 +360,53 @@ body.page-characters::-webkit-scrollbar {
 .stats-grid {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 20px;
   padding: 16px 0 20px;
-  max-width: 70%;
+  max-width: 80%;
   margin: 0 auto;
 }
 .stat-row {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   background: transparent;
   border: none;
   padding: 0;
+  gap: 8px;
 }
 .stat-row img {
   width: auto;
-  height: 60px;
+  height: 100px;
   object-fit: contain;
 }
 .stat-label {
   display: none;
 }
 .stat-value {
-  display: none;
+  color: #fff;
+  font-size: 24px;
+  font-weight: 700;
+  text-shadow: 0 2px 4px rgba(0,0,0,0.9);
 }
 
 /* Power stat styling - REMOVED (replaced by power holder) */
 
-/* Power Holder Display */
+/* Power Holder Display - Positioned under character art */
+#char-power-holder-container {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  z-index: 10;
+}
 .power-holder-container {
   position: relative;
   width: 550px;
   height: 160px;
-  margin: 20px auto 0;
   background-image: url('../assets/icons/powerholder.png');
   background-size: contain;
   background-position: center;
@@ -429,6 +443,11 @@ body.page-characters::-webkit-scrollbar {
   text-shadow: 0 2px 4px rgba(0,0,0,0.9);
   letter-spacing: 1px;
   flex-shrink: 0;
+}
+
+/* Make sure char-modal-art has position relative for absolute positioning */
+.char-modal-art {
+  position: relative;
 }
 
 /* ---------- Level / Growth Section ---------- */

--- a/js/characters.js
+++ b/js/characters.js
@@ -379,6 +379,7 @@
       const powerGrade = calculatePowerGrade(power, unlockedAbilities);
       const totalPower = power + (unlockedAbilities * 30000);
 
+      // Render stats
       STATS_WRAP.innerHTML = `
         <div class="stat-row">
           <img src="assets/ui/healthstat.png" alt="Health" />
@@ -394,13 +395,19 @@
           <img src="assets/ui/speedstat.png" alt="Speed" />
           <span class="stat-label">Speed</span>
           <span class="stat-value">${stats.speed ?? "-"}</span>
-        </div>
-        <div class="power-holder-container">
-          <div class="power-holder-content">
-            <div class="power-grade">${getPowerGradeElement(powerGrade)}</div>
-            <div class="power-value">${totalPower.toLocaleString()}</div>
-          </div>
         </div>`;
+
+      // Render power holder under character art
+      const powerHolderContainer = document.getElementById('char-power-holder-container');
+      if (powerHolderContainer) {
+        powerHolderContainer.innerHTML = `
+          <div class="power-holder-container">
+            <div class="power-holder-content">
+              <div class="power-grade">${getPowerGradeElement(powerGrade)}</div>
+              <div class="power-value">${totalPower.toLocaleString()}</div>
+            </div>
+          </div>`;
+      }
     } else {
       const s = c.statsBase || {};
 
@@ -425,6 +432,7 @@
       const powerGrade = calculatePowerGrade(power, unlockedAbilities);
       const totalPower = power + (unlockedAbilities * 30000);
 
+      // Render stats
       STATS_WRAP.innerHTML = `
         <div class="stat-row">
           <img src="assets/ui/healthstat.png" alt="Health" />
@@ -440,13 +448,19 @@
           <img src="assets/ui/speedstat.png" alt="Speed" />
           <span class="stat-label">Speed</span>
           <span class="stat-value">${s.speed ?? "-"}</span>
-        </div>
-        <div class="power-holder-container">
-          <div class="power-holder-content">
-            <div class="power-grade">${getPowerGradeElement(powerGrade)}</div>
-            <div class="power-value">${totalPower.toLocaleString()}</div>
-          </div>
         </div>`;
+
+      // Render power holder under character art
+      const powerHolderContainer = document.getElementById('char-power-holder-container');
+      if (powerHolderContainer) {
+        powerHolderContainer.innerHTML = `
+          <div class="power-holder-container">
+            <div class="power-holder-content">
+              <div class="power-grade">${getPowerGradeElement(powerGrade)}</div>
+              <div class="power-value">${totalPower.toLocaleString()}</div>
+            </div>
+          </div>`;
+      }
     }
 
     // Get base tier cap (without limit breaks) for awakening checks


### PR DESCRIPTION
Critical Fixes:
1. Restored stat values (numbers) display below each stat icon
   - User wanted labels removed (Health/Attack/Speed text)
   - But values (19122, 1668, 118) should remain visible
   - Stat values now show below each PNG in 24px font

2. Made stat PNGs BIGGER (not smaller!)
   - Changed from 32px → 100px height (was incorrectly reduced to 60px)
   - Stats now properly enlarged as requested
   - Icons displayed in vertical column with values below

3. Repositioned power holder under character picture
   - Moved from stats panel (right side) to under character art (left side)
   - Added #char-power-holder-container in HTML under .char-modal-art
   - Positioned absolutely at bottom center of character art section
   - Power holder now appears below character image as shown in reference

Layout Changes:
- Stat rows now use flex-direction: column for icon-above-value layout
- Removed text labels (Health, Attack, Speed) - shown in PNGs
- Power holder renders separately in new container
- Made .char-modal-art position: relative for absolute child positioning