### PR TITLE
Arrange stats horizontally, reposition power holder, and replace lock…

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -360,34 +360,38 @@ body.page-characters::-webkit-scrollbar {
 .stats-grid {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 12px;
   padding: 16px 0 20px;
-  max-width: 80%;
+  max-width: 90%;
   margin: 0 auto;
 }
 .stat-row {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   background: transparent;
   border: none;
-  padding: 0;
-  gap: 8px;
+  padding: 8px 20px;
+  gap: 20px;
 }
 .stat-row img {
-  width: auto;
-  height: 100px;
-  object-fit: contain;
+  display: none;
 }
 .stat-label {
-  display: none;
+  display: block;
+  color: #d9b362;
+  font-size: 18px;
+  font-weight: 600;
+  text-align: left;
+  flex: 1;
 }
 .stat-value {
   color: #fff;
-  font-size: 24px;
+  font-size: 20px;
   font-weight: 700;
   text-shadow: 0 2px 4px rgba(0,0,0,0.9);
+  text-align: right;
 }
 
 /* Power stat styling - REMOVED (replaced by power holder) */
@@ -395,12 +399,12 @@ body.page-characters::-webkit-scrollbar {
 /* Power Holder Display - Positioned under character art */
 #char-power-holder-container {
   position: absolute;
-  bottom: 20px;
-  left: 50%;
+  bottom: 5px;
+  left: 35%;
   transform: translateX(-50%);
   width: 100%;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   z-index: 10;
 }
 .power-holder-container {
@@ -413,8 +417,9 @@ body.page-characters::-webkit-scrollbar {
   background-repeat: no-repeat;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 0 60px 0 50px;
+  justify-content: flex-start;
+  padding: 0 30px 0 50px;
+  gap: 15px;
 }
 .power-holder-content {
   display: contents;
@@ -448,6 +453,34 @@ body.page-characters::-webkit-scrollbar {
 /* Make sure char-modal-art has position relative for absolute positioning */
 .char-modal-art {
   position: relative;
+}
+
+/* Lock Icon Styling */
+.lock-icon {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.8));
+}
+.skill-card.locked,
+.ability-card.locked {
+  position: relative;
+}
+.skill-card.locked .lock-overlay,
+.ability-card.locked .lock-overlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 5;
+  pointer-events: none;
+}
+.skill-card.locked .lock-overlay img,
+.ability-card.locked .lock-overlay img {
+  width: 60px;
+  height: 60px;
+  object-fit: contain;
+  filter: drop-shadow(0 4px 8px rgba(0,0,0,0.9));
 }
 
 /* ---------- Level / Growth Section ---------- */
@@ -1028,12 +1061,8 @@ body.page-characters::-webkit-scrollbar {
 }
 
 .ability-card.locked::before {
-  content: "🔒";
-  position: absolute;
-  top: 8px;
-  right: 12px;
-  font-size: 16px;
-  opacity: 0.6;
+  content: "";
+  display: none;
 }
 
 .ability-header {

--- a/js/characters.js
+++ b/js/characters.js
@@ -1425,11 +1425,13 @@
       const e = pickTierSkillEntry(jutsu, tier, minT);
       if (e) {
         // Check if jutsu is unlocked by level
-        const lockStatus = jutsuUnlocked ? '' : ` <span style="color:#d8b86a">🔒 (Requires Lv 20)</span>`;
+        const lockOverlay = jutsuUnlocked ? '' : `<div class="lock-overlay"><img src="assets/ui/locked.png" alt="Locked" onerror="this.style.display='none';" /></div>`;
+        const lockStatus = jutsuUnlocked ? '' : ` <span style="color:#d8b86a">(Requires Lv 20)</span>`;
         const cardClass = jutsuUnlocked ? '' : ' locked';
         const multiplier = extractMultiplier(e);
         cards.push(`
           <div class="skill-card${cardClass}">
+            ${lockOverlay}
             <div class="skill-header"><span class="skill-type">Ninjutsu</span><span class="skill-name">${safeStr(jutsu.name,"Ninjutsu")}${lockStatus}</span></div>
             <div class="skill-meta">
               <span>Chakra: <strong>${safeNum(e.chakraCost,"-")}</strong></span>
@@ -1448,11 +1450,13 @@
       const e = pickTierSkillEntry(ultimate, tier, null);
       if (e) {
         // Check if ultimate is unlocked by level
-        const lockStatus = ultimateUnlocked ? '' : ` <span style="color:#d8b86a">🔒 (Requires Lv 50)</span>`;
+        const lockOverlay = ultimateUnlocked ? '' : `<div class="lock-overlay"><img src="assets/ui/locked.png" alt="Locked" onerror="this.style.display='none';" /></div>`;
+        const lockStatus = ultimateUnlocked ? '' : ` <span style="color:#d8b86a">(Requires Lv 50)</span>`;
         const cardClass = ultimateUnlocked ? '' : ' locked';
         const multiplier = extractMultiplier(e);
         cards.push(`
           <div class="skill-card ultimate${cardClass}">
+            ${lockOverlay}
             <div class="skill-header"><span class="skill-type">Ultimate</span><span class="skill-name">${safeStr(ultimate.name,"Ultimate")}${lockStatus}</span></div>
             <div class="skill-meta">
               <span>Chakra: <strong>${safeNum(e.chakraCost,"-")}</strong></span>
@@ -1467,7 +1471,8 @@
       } else {
         cards.push(`
           <div class="skill-card ultimate locked">
-            <div class="skill-header"><span class="skill-type">Ultimate</span><span class="skill-name">${safeStr(ultimate.name,"Ultimate")} <span style="color:#d8b86a">🔒 (Tier Locked)</span></span></div>
+            <div class="lock-overlay"><img src="assets/ui/locked.png" alt="Locked" onerror="this.style.display='none';" /></div>
+            <div class="skill-header"><span class="skill-type">Ultimate</span><span class="skill-name">${safeStr(ultimate.name,"Ultimate")} <span style="color:#d8b86a">(Tier Locked)</span></span></div>
             <div class="skill-desc">Unlocks upon awakening to a higher star tier.</div>
           </div>
         `);
@@ -1557,11 +1562,13 @@
     c.abilities.forEach((ability, index) => {
       const isUnlocked = unlockedAbilities.includes(index);
       const lockClass = isUnlocked ? '' : 'locked';
+      const lockOverlay = isUnlocked ? '' : '<div class="lock-overlay"><img src="assets/ui/locked.png" alt="Locked" onerror="this.style.display=\'none\';" /></div>';
       const statusText = isUnlocked ? 'UNLOCKED' : 'LOCKED';
       const statusClass = isUnlocked ? '' : 'locked';
 
       html += `
         <div class="ability-card ${lockClass}">
+          ${lockOverlay}
           <div class="ability-header">
             <div class="ability-name">${ability.name || `Ability ${index + 1}`}</div>
             <div class="ability-unlock-status ${statusClass}">${statusText}</div>


### PR DESCRIPTION
… emojis

Stat Display Changes:
- Changed stats layout to horizontal: StatName (left) | StatValue (right)
- Stat labels now visible and styled: 18px, gold color (#d9b362)
- Stat values: 20px, white, right-aligned
- Hidden stat PNG icons (redundant with text labels)
- Layout uses space-between for proper alignment
- Reference: CP, HP, P.Tech, C.Tech format

Power Holder Positioning:
- Moved power holder LEFT: from center (50%) to left-of-center (35%)
- Moved CLOSER to character art: bottom: 20px → 5px
- Reduced gap between grade and power value: 60px padding → 30px padding
- Added gap: 15px between grade image and power number
- Changed justify-content to flex-start for tighter layout

Lock Icon System:
- Replaced ALL 🔒 emojis with locked.png image overlay
- Lock displays centered over locked content (skills, abilities)
- Lock image: 60px size with drop-shadow effect
- Added .lock-overlay container with absolute positioning
- Lock automatically disappears when requirements met (conditional rendering)
- Applied to:
  * Ninjutsu (locked until Lv 20)
  * Ultimate (locked until Lv 50)
  * Ultimate tier-locked skills
  * Locked abilities

Note: User needs to add assets/ui/locked.png file (fallback: hide if missing)