### PR TITLE
Add equipment grid and dividers, fix locked icon path

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -455,6 +455,47 @@ body.page-characters::-webkit-scrollbar {
   position: relative;
 }
 
+/* Stats and Equipment Dividers */
+.stats-divider,
+.equip-divider {
+  width: 100%;
+  margin: 20px 0;
+  display: flex;
+  justify-content: center;
+}
+.stats-divider img,
+.equip-divider img {
+  width: 100%;
+  max-width: 600px;
+  height: auto;
+  object-fit: contain;
+}
+
+/* Equipment Grid - 2 rows of 7 slots */
+.equipment-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+  gap: 8px;
+  padding: 10px 0;
+  max-width: 90%;
+  margin: 0 auto;
+}
+.equipment-slot {
+  position: relative;
+  aspect-ratio: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  overflow: hidden;
+}
+.equipment-slot img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
 /* Lock Icon Styling */
 .lock-icon {
   width: 40px;

--- a/js/characters.js
+++ b/js/characters.js
@@ -395,6 +395,15 @@
           <img src="assets/ui/speedstat.png" alt="Speed" />
           <span class="stat-label">Speed</span>
           <span class="stat-value">${stats.speed ?? "-"}</span>
+        </div>
+        <div class="stats-divider">
+          <img src="assets/stats/statsdiv.png" alt="" onerror="this.style.display='none';" />
+        </div>
+        <div class="equip-divider">
+          <img src="assets/stats/equipdiv.png" alt="" onerror="this.style.display='none';" />
+        </div>
+        <div class="equipment-grid">
+          ${Array(14).fill(0).map((_, i) => `<div class="equipment-slot"><img src="assets/stats/emptyslot.png" alt="Empty Slot" onerror="this.style.display='none';" /></div>`).join('')}
         </div>`;
 
       // Render power holder under character art
@@ -448,6 +457,15 @@
           <img src="assets/ui/speedstat.png" alt="Speed" />
           <span class="stat-label">Speed</span>
           <span class="stat-value">${s.speed ?? "-"}</span>
+        </div>
+        <div class="stats-divider">
+          <img src="assets/stats/statsdiv.png" alt="" onerror="this.style.display='none';" />
+        </div>
+        <div class="equip-divider">
+          <img src="assets/stats/equipdiv.png" alt="" onerror="this.style.display='none';" />
+        </div>
+        <div class="equipment-grid">
+          ${Array(14).fill(0).map((_, i) => `<div class="equipment-slot"><img src="assets/stats/emptyslot.png" alt="Empty Slot" onerror="this.style.display='none';" /></div>`).join('')}
         </div>`;
 
       // Render power holder under character art
@@ -1425,7 +1443,7 @@
       const e = pickTierSkillEntry(jutsu, tier, minT);
       if (e) {
         // Check if jutsu is unlocked by level
-        const lockOverlay = jutsuUnlocked ? '' : `<div class="lock-overlay"><img src="assets/ui/locked.png" alt="Locked" onerror="this.style.display='none';" /></div>`;
+        const lockOverlay = jutsuUnlocked ? '' : `<div class="lock-overlay"><img src="assets/icons/locked.png" alt="Locked" onerror="this.style.display='none';" /></div>`;
         const lockStatus = jutsuUnlocked ? '' : ` <span style="color:#d8b86a">(Requires Lv 20)</span>`;
         const cardClass = jutsuUnlocked ? '' : ' locked';
         const multiplier = extractMultiplier(e);
@@ -1450,7 +1468,7 @@
       const e = pickTierSkillEntry(ultimate, tier, null);
       if (e) {
         // Check if ultimate is unlocked by level
-        const lockOverlay = ultimateUnlocked ? '' : `<div class="lock-overlay"><img src="assets/ui/locked.png" alt="Locked" onerror="this.style.display='none';" /></div>`;
+        const lockOverlay = ultimateUnlocked ? '' : `<div class="lock-overlay"><img src="assets/icons/locked.png" alt="Locked" onerror="this.style.display='none';" /></div>`;
         const lockStatus = ultimateUnlocked ? '' : ` <span style="color:#d8b86a">(Requires Lv 50)</span>`;
         const cardClass = ultimateUnlocked ? '' : ' locked';
         const multiplier = extractMultiplier(e);
@@ -1471,7 +1489,7 @@
       } else {
         cards.push(`
           <div class="skill-card ultimate locked">
-            <div class="lock-overlay"><img src="assets/ui/locked.png" alt="Locked" onerror="this.style.display='none';" /></div>
+            <div class="lock-overlay"><img src="assets/icons/locked.png" alt="Locked" onerror="this.style.display='none';" /></div>
             <div class="skill-header"><span class="skill-type">Ultimate</span><span class="skill-name">${safeStr(ultimate.name,"Ultimate")} <span style="color:#d8b86a">(Tier Locked)</span></span></div>
             <div class="skill-desc">Unlocks upon awakening to a higher star tier.</div>
           </div>
@@ -1562,7 +1580,7 @@
     c.abilities.forEach((ability, index) => {
       const isUnlocked = unlockedAbilities.includes(index);
       const lockClass = isUnlocked ? '' : 'locked';
-      const lockOverlay = isUnlocked ? '' : '<div class="lock-overlay"><img src="assets/ui/locked.png" alt="Locked" onerror="this.style.display=\'none\';" /></div>';
+      const lockOverlay = isUnlocked ? '' : '<div class="lock-overlay"><img src="assets/icons/locked.png" alt="Locked" onerror="this.style.display=\'none\';" /></div>';
       const statusText = isUnlocked ? 'UNLOCKED' : 'LOCKED';
       const statusClass = isUnlocked ? '' : 'locked';
 


### PR DESCRIPTION
Lock Icon Path Fix:
- Changed locked.png path from assets/ui/ to assets/icons/
- Updated all lock overlays in:
  * Ninjutsu skills (Lv 20 requirement)
  * Ultimate skills (Lv 50 requirement)
  * Tier-locked ultimates
  * Locked abilities

Stats and Equipment Dividers:
- Added statsdiv.png divider after stats section
- Added equipdiv.png divider before equipment section
- Both dividers centered, max-width 600px
- Image paths: assets/stats/statsdiv.png and assets/stats/equipdiv.png
- Graceful fallback: hide if images missing (onerror)

Equipment Grid System:
- Added 14-slot equipment grid (2 rows × 7 columns)
- Each slot displays assets/stats/emptyslot.png
- Grid layout: repeat(7, 1fr) columns, repeat(2, 1fr) rows
- 8px gap between slots, 90% max-width
- Aspect ratio: 1:1 (square slots)
- Rounded corners (8px border-radius)

Required Assets (user must add):
- assets/icons/locked.png - Lock overlay icon
- assets/stats/statsdiv.png - Stats divider image
- assets/stats/equipdiv.png - Equipment divider image
- assets/stats/emptyslot.png - Empty equipment slot image