### PR TITLE
Reposition dividers and reduce equipment slots

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -471,10 +471,10 @@ body.page-characters::-webkit-scrollbar {
   object-fit: contain;
 }
 
-/* Equipment Grid - 2 rows of 7 slots */
+/* Equipment Grid - 2 rows of 5 slots */
 .equipment-grid {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   grid-template-rows: repeat(2, 1fr);
   gap: 8px;
   padding: 10px 0;

--- a/js/characters.js
+++ b/js/characters.js
@@ -381,6 +381,9 @@
 
       // Render stats
       STATS_WRAP.innerHTML = `
+        <div class="stats-divider">
+          <img src="assets/Stats/statsdiv.png" alt="" onerror="this.style.display='none';" />
+        </div>
         <div class="stat-row">
           <img src="assets/ui/healthstat.png" alt="Health" />
           <span class="stat-label">Health</span>
@@ -396,14 +399,11 @@
           <span class="stat-label">Speed</span>
           <span class="stat-value">${stats.speed ?? "-"}</span>
         </div>
-        <div class="stats-divider">
-          <img src="assets/Stats/statsdiv.png" alt="" onerror="this.style.display='none';" />
-        </div>
         <div class="equip-divider">
           <img src="assets/Stats/equipdiv.png" alt="" onerror="this.style.display='none';" />
         </div>
         <div class="equipment-grid">
-          ${Array(14).fill(0).map((_, i) => `<div class="equipment-slot"><img src="assets/Stats/emptyslot.png" alt="Empty Slot" onerror="this.style.display='none';" /></div>`).join('')}
+          ${Array(10).fill(0).map((_, i) => `<div class="equipment-slot"><img src="assets/Stats/emptyslot.png" alt="Empty Slot" onerror="this.style.display='none';" /></div>`).join('')}
         </div>`;
 
       // Render power holder under character art
@@ -443,6 +443,9 @@
 
       // Render stats
       STATS_WRAP.innerHTML = `
+        <div class="stats-divider">
+          <img src="assets/Stats/statsdiv.png" alt="" onerror="this.style.display='none';" />
+        </div>
         <div class="stat-row">
           <img src="assets/ui/healthstat.png" alt="Health" />
           <span class="stat-label">Health</span>
@@ -458,14 +461,11 @@
           <span class="stat-label">Speed</span>
           <span class="stat-value">${s.speed ?? "-"}</span>
         </div>
-        <div class="stats-divider">
-          <img src="assets/Stats/statsdiv.png" alt="" onerror="this.style.display='none';" />
-        </div>
         <div class="equip-divider">
           <img src="assets/Stats/equipdiv.png" alt="" onerror="this.style.display='none';" />
         </div>
         <div class="equipment-grid">
-          ${Array(14).fill(0).map((_, i) => `<div class="equipment-slot"><img src="assets/Stats/emptyslot.png" alt="Empty Slot" onerror="this.style.display='none';" /></div>`).join('')}
+          ${Array(10).fill(0).map((_, i) => `<div class="equipment-slot"><img src="assets/Stats/emptyslot.png" alt="Empty Slot" onerror="this.style.display='none';" /></div>`).join('')}
         </div>`;
 
       // Render power holder under character art


### PR DESCRIPTION
- Move statsdiv above stats section
- Move equipdiv below stats, above equipment grid
- Reduce equipment grid from 14 slots (2x7) to 10 slots (2x5)
- Update CSS grid-template-columns from repeat(7, 1fr) to repeat(5, 1fr)