### PR TITLE
Increase divider overlap to position content within gradients

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -361,7 +361,7 @@ body.page-characters::-webkit-scrollbar {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  padding: 8px 0 10px;
+  padding: 0;
   max-width: 90%;
   margin: 0 auto;
 }
@@ -372,7 +372,7 @@ body.page-characters::-webkit-scrollbar {
   justify-content: space-between;
   background: transparent;
   border: none;
-  padding: 4px 20px;
+  padding: 0 20px;
   gap: 20px;
 }
 .stat-row img {
@@ -459,7 +459,7 @@ body.page-characters::-webkit-scrollbar {
 .stats-divider,
 .equip-divider {
   width: 100%;
-  margin: 0 0 -30px 0;  /* Negative bottom margin creates overlap */
+  margin: 0 0 -80px 0;  /* Negative bottom margin creates overlap - content sits in gradient */
   display: flex;
   justify-content: center;
   position: relative;


### PR DESCRIPTION
- Increase divider negative margin from -30px to -80px for deeper overlap
- Remove all padding from stats-grid (was 8px 0 10px, now 0)
- Remove vertical padding from stat-row (was 4px 20px, now 0 20px)
- Content now sits properly within the divider gradient areas