### PR TITLE
Implement comprehensive jutsu/ultimate equipment system

### DIFF
--- a/characters.html
+++ b/characters.html
@@ -43,6 +43,30 @@
       <div class="char-modal-art">
         <img id="char-modal-img" src="" alt="Character full art" />
         <div id="char-power-holder-container"></div>
+
+        <!-- Jutsu/Ultimate Slots -->
+        <div class="jutsu-slots-container" id="jutsu-slots-container">
+          <div class="jutsu-row">
+            <button class="jutsu-slot" data-slot="jutsu1">
+              <img src="assets/ui/jutuslotempty.png" alt="Jutsu Slot 1" class="jutsu-slot-bg">
+              <img src="" alt="" class="jutsu-slot-icon" style="display:none;">
+            </button>
+            <button class="jutsu-slot" data-slot="jutsu2">
+              <img src="assets/ui/jutuslotempty.png" alt="Jutsu Slot 2" class="jutsu-slot-bg">
+              <img src="" alt="" class="jutsu-slot-icon" style="display:none;">
+            </button>
+            <button class="jutsu-slot" data-slot="jutsu3">
+              <img src="assets/ui/jutuslotempty.png" alt="Jutsu Slot 3" class="jutsu-slot-bg">
+              <img src="" alt="" class="jutsu-slot-icon" style="display:none;">
+            </button>
+          </div>
+          <div class="ultimate-row">
+            <button class="ultimate-slot" data-slot="ultimate">
+              <img src="assets/ui/ultimateslotempty.png" alt="Ultimate Slot" class="ultimate-slot-bg">
+              <img src="" alt="" class="ultimate-slot-icon" style="display:none;">
+            </button>
+          </div>
+        </div>
       </div>
       <div class="char-modal-info">
         <div class="nameplate">
@@ -232,7 +256,7 @@
   <!-- Card Inventory Modal (for Equipment Slots) -->
   <div id="card-inventory-modal" class="card-inventory-modal" aria-hidden="true">
     <div class="card-inventory-panel">
-      <h2 class="card-inventory-title">Select Character Card</h2>
+      <h2 class="card-inventory-title">Select Jutsu Card</h2>
       <div class="card-inventory-grid" id="card-inventory-grid"></div>
       <div class="card-inventory-actions">
         <button class="btn-dark" id="card-inventory-cancel">Cancel</button>
@@ -240,8 +264,18 @@
     </div>
   </div>
 
-  <!-- Radial Pie Menu / Ability Wheel -->
-  <div class="radial-menu-container" id="radial-menu" style="display: none;">
+  <!-- Jutsu Replacement Popup -->
+  <div id="jutsu-replacement-modal" class="jutsu-replacement-modal" aria-hidden="true">
+    <div class="jutsu-replacement-popup">
+      <h3 class="replacement-title">All Jutsu Slots Full!</h3>
+      <p class="replacement-message">Select which jutsu to replace:</p>
+      <div class="replacement-options" id="replacement-options"></div>
+      <button class="btn-dark" id="replacement-cancel">Cancel</button>
+    </div>
+  </div>
+
+  <!-- Radial Pie Menu / Ability Wheel (DEPRECATED - Now using in-modal jutsu slots) -->
+  <div class="radial-menu-container" id="radial-menu" style="display: none !important;">
     <button class="radial-anchor-btn" id="radial-anchor" aria-label="Open Actions Menu">
       +
     </button>

--- a/css/characters.css
+++ b/css/characters.css
@@ -1819,3 +1819,159 @@ body.page-characters::-webkit-scrollbar {
   gap: 12px;
   margin-top: 20px;
 }
+
+/* ========== Jutsu/Ultimate Slots (Inside Character Modal) ========== */
+.jutsu-slots-container {
+  position: absolute;
+  bottom: 80px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 15;
+}
+
+.jutsu-row {
+  display: flex;
+  gap: 8px;
+}
+
+.ultimate-row {
+  display: flex;
+  justify-content: center;
+}
+
+.jutsu-slot,
+.ultimate-slot {
+  position: relative;
+  width: 70px;
+  height: 70px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  padding: 0;
+}
+
+.jutsu-slot-bg,
+.ultimate-slot-bg {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  pointer-events: none;
+}
+
+.jutsu-slot-icon,
+.ultimate-slot-icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 80%;
+  height: 80%;
+  object-fit: contain;
+  pointer-events: none;
+}
+
+.jutsu-slot:hover,
+.ultimate-slot:hover {
+  transform: scale(1.1);
+  filter: brightness(1.2);
+}
+
+.jutsu-slot:active,
+.ultimate-slot:active {
+  transform: scale(0.95);
+}
+
+.ultimate-slot {
+  width: 90px;
+  height: 90px;
+}
+
+/* ========== Jutsu Replacement Popup (infoframe.png background) ========== */
+.jutsu-replacement-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.4);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 2500;
+}
+
+.jutsu-replacement-modal[aria-hidden="false"] {
+  display: flex;
+}
+
+.jutsu-replacement-popup {
+  background-image: url('../assets/ui/infoframe.png');
+  background-size: 100% 100%;
+  background-repeat: no-repeat;
+  background-position: center;
+  width: 500px;
+  min-height: 350px;
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.replacement-title {
+  font-family: "Cinzel", serif;
+  font-size: 22px;
+  color: #d9b362;
+  text-align: center;
+  margin: 0;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8);
+}
+
+.replacement-message {
+  font-family: "Cinzel", serif;
+  font-size: 16px;
+  color: #fff;
+  text-align: center;
+  margin: 0;
+}
+
+.replacement-options {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+}
+
+.replacement-option {
+  background: rgba(10, 10, 15, 0.8);
+  border: 2px solid rgba(217, 179, 98, 0.3);
+  border-radius: 8px;
+  padding: 12px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.replacement-option:hover {
+  border-color: rgba(217, 179, 98, 0.7);
+  background: rgba(20, 20, 25, 0.9);
+  transform: translateX(4px);
+}
+
+.replacement-option img {
+  width: 50px;
+  height: 50px;
+  object-fit: contain;
+}
+
+.replacement-option-name {
+  font-family: "Cinzel", serif;
+  font-size: 14px;
+  color: #fff;
+  flex: 1;
+}

--- a/data/jutsu_cards.json
+++ b/data/jutsu_cards.json
@@ -1,0 +1,67 @@
+{
+  "cards": [
+    {
+      "id": "water_fang_typhoon",
+      "name": "Water Style: Super Water Fang Typhoon Jutsu",
+      "type": "jutsu",
+      "element": "water",
+      "fullArt": "assets/jutsu/cards/water_fang_full.png",
+      "icon": "assets/jutsu/icons/water_fang_icon.png",
+      "description": "Massive water technique that creates a typhoon"
+    },
+    {
+      "id": "fire_dragon_flame",
+      "name": "Fire Style: Fire Dragon Flame Jutsu",
+      "type": "jutsu",
+      "element": "fire",
+      "fullArt": "assets/jutsu/cards/fire_dragon_full.png",
+      "icon": "assets/jutsu/icons/fire_dragon_icon.png",
+      "description": "Unleashes a dragon-shaped flame"
+    },
+    {
+      "id": "rasengan",
+      "name": "Rasengan",
+      "type": "jutsu",
+      "element": "neutral",
+      "fullArt": "assets/jutsu/cards/rasengan_full.png",
+      "icon": "assets/jutsu/icons/rasengan_icon.png",
+      "description": "A spinning ball of chakra"
+    },
+    {
+      "id": "chidori",
+      "name": "Chidori",
+      "type": "jutsu",
+      "element": "lightning",
+      "fullArt": "assets/jutsu/cards/chidori_full.png",
+      "icon": "assets/jutsu/icons/chidori_icon.png",
+      "description": "Lightning blade piercing technique"
+    },
+    {
+      "id": "rasen_shuriken",
+      "name": "Wind Style: Rasenshuriken",
+      "type": "ultimate",
+      "element": "wind",
+      "fullArt": "assets/jutsu/cards/rasenshuriken_full.png",
+      "icon": "assets/jutsu/icons/rasenshuriken_icon.png",
+      "description": "Ultimate wind release technique"
+    },
+    {
+      "id": "kirin",
+      "name": "Kirin",
+      "type": "ultimate",
+      "element": "lightning",
+      "fullArt": "assets/jutsu/cards/kirin_full.png",
+      "icon": "assets/jutsu/icons/kirin_icon.png",
+      "description": "Lightning beast ultimate technique"
+    },
+    {
+      "id": "amaterasu",
+      "name": "Amaterasu",
+      "type": "ultimate",
+      "element": "fire",
+      "fullArt": "assets/jutsu/cards/amaterasu_full.png",
+      "icon": "assets/jutsu/icons/amaterasu_icon.png",
+      "description": "Black flames that never extinguish"
+    }
+  ]
+}


### PR DESCRIPTION
JUTSU SLOTS:
- Move jutsu/ultimate buttons inside character modal (below power holder)
- Add 3 jutsu slots + 1 ultimate slot with jutuslotempty/ultimateslotempty backgrounds
- Position slots in bottom-right of character art area

JUTSU CARDS JSON:
- Create data/jutsu_cards.json with sample cards (Water Fang, Rasengan, Chidori, etc.)
- Define card structure: id, name, type (jutsu/ultimate), fullArt, icon, element, description

EQUIPMENT LOGIC:
- Click equipment slot → opens jutsu card inventory modal
- Display all available jutsu cards from JSON
- Check card type and equip to appropriate slot
- Ultimate cards → ultimate slot
- Jutsu cards → first empty jutsu slot (jutsu1, jutsu2, or jutsu3)

DUPLICATE PREVENTION:
- Check if card already equipped before allowing selection
- Alert user if they try to equip same card twice
- Prevents duplicate jutsu across all 3 jutsu slots

VERSION PERSISTENCE:
- Store equipped jutsu in character instance (inst.equippedJutsu)
- Persist data using InventoryChar.updateInstance
- Maintains equipment across sessions

FULL SLOTS POPUP:
- When all 3 jutsu slots full and user adds 4th unique jutsu
- Show replacement popup with infoframe.png background
- Display current 3 equipped jutsu with icons
- User selects which jutsu to replace
- Popup smaller to show character modal beneath (hierarchy)

INTEGRATION:
- Call renderJutsuSlots(uid) when opening character modal
- Automatically loads and displays equipped jutsu icons
- Hide deprecated bottom-right radial menu