### PR TITLE
Fix jutsu slots visibility and remove deprecated radial menu

### DIFF
--- a/characters.html
+++ b/characters.html
@@ -46,26 +46,22 @@
 
         <!-- Jutsu/Ultimate Slots -->
         <div class="jutsu-slots-container" id="jutsu-slots-container">
-          <div class="jutsu-row">
-            <button class="jutsu-slot" data-slot="jutsu1">
-              <img src="assets/ui/jutsuslotempty.png" alt="Jutsu Slot 1" class="jutsu-slot-bg">
-              <img src="" alt="" class="jutsu-slot-icon" style="display:none;">
-            </button>
-            <button class="jutsu-slot" data-slot="jutsu2">
-              <img src="assets/ui/jutsuslotempty.png" alt="Jutsu Slot 2" class="jutsu-slot-bg">
-              <img src="" alt="" class="jutsu-slot-icon" style="display:none;">
-            </button>
-            <button class="jutsu-slot" data-slot="jutsu3">
-              <img src="assets/ui/jutsuslotempty.png" alt="Jutsu Slot 3" class="jutsu-slot-bg">
-              <img src="" alt="" class="jutsu-slot-icon" style="display:none;">
-            </button>
-          </div>
-          <div class="ultimate-row">
-            <button class="ultimate-slot" data-slot="ultimate">
-              <img src="assets/ui/ultimateslotemtpy.png" alt="Ultimate Slot" class="ultimate-slot-bg">
-              <img src="" alt="" class="ultimate-slot-icon" style="display:none;">
-            </button>
-          </div>
+          <button class="jutsu-slot" data-slot="jutsu1">
+            <img src="assets/ui/jutsuslotempty.png" alt="Jutsu Slot 1" class="jutsu-slot-bg">
+            <img src="" alt="" class="jutsu-slot-icon" style="display:none;">
+          </button>
+          <button class="jutsu-slot" data-slot="jutsu2">
+            <img src="assets/ui/jutsuslotempty.png" alt="Jutsu Slot 2" class="jutsu-slot-bg">
+            <img src="" alt="" class="jutsu-slot-icon" style="display:none;">
+          </button>
+          <button class="jutsu-slot" data-slot="jutsu3">
+            <img src="assets/ui/jutsuslotempty.png" alt="Jutsu Slot 3" class="jutsu-slot-bg">
+            <img src="" alt="" class="jutsu-slot-icon" style="display:none;">
+          </button>
+          <button class="ultimate-slot" data-slot="ultimate">
+            <img src="assets/ui/ultimateslotemtpy.png" alt="Ultimate Slot" class="ultimate-slot-bg">
+            <img src="" alt="" class="ultimate-slot-icon" style="display:none;">
+          </button>
         </div>
       </div>
       <div class="char-modal-info">
@@ -271,27 +267,6 @@
       <p class="replacement-message">Select which jutsu to replace:</p>
       <div class="replacement-options" id="replacement-options"></div>
       <button class="btn-dark" id="replacement-cancel">Cancel</button>
-    </div>
-  </div>
-
-  <!-- Radial Pie Menu / Ability Wheel (DEPRECATED - Now using in-modal jutsu slots) -->
-  <div class="radial-menu-container" id="radial-menu" style="display: none !important;">
-    <button class="radial-anchor-btn" id="radial-anchor" aria-label="Open Actions Menu">
-      +
-    </button>
-    <div class="radial-satellites" id="radial-satellites">
-      <button class="radial-satellite-btn" data-action="ninjutsu" style="--angle: 0deg;">
-        <img src="assets/ui/jutsuslotempty.png" alt="Ninjutsu">
-      </button>
-      <button class="radial-satellite-btn" data-action="ultimate" style="--angle: 90deg;">
-        <img src="assets/ui/ultimateslotemtpy.png" alt="Ultimate">
-      </button>
-      <button class="radial-satellite-btn" data-action="skill1" style="--angle: 180deg;">
-        <img src="assets/ui/jutsuslotempty.png" alt="Skill 1">
-      </button>
-      <button class="radial-satellite-btn" data-action="skill2" style="--angle: 270deg;">
-        <img src="assets/ui/jutsuslotempty.png" alt="Skill 2">
-      </button>
     </div>
   </div>
 

--- a/css/characters.css
+++ b/css/characters.css
@@ -1821,7 +1821,6 @@ body.page-characters::-webkit-scrollbar {
 }
 
 /* ========== Jutsu/Ultimate Slots (Inside Character Modal) ========== */
-/* ========== Jutsu/Ultimate Slots (Inside Character Modal) ========== */
 .jutsu-slots-container {
   position: absolute;
   bottom: 50px;
@@ -1829,11 +1828,6 @@ body.page-characters::-webkit-scrollbar {
   width: 200px;
   height: 200px;
   z-index: 15;
-}
-
-.jutsu-row,
-.ultimate-row {
-  display: none; /* Hide flex containers, use absolute positioning */
 }
 
 .jutsu-slot,


### PR DESCRIPTION
- Remove jutsu-row and ultimate-row wrapper divs from HTML
- Place slots directly in jutsu-slots-container
- Remove display:none CSS rule that was hiding wrapper divs
- Delete deprecated radial-menu-container outside character modal
- Slots now properly visible in circular arrangement inside character modal