### PR TITLE
Arrange jutsu/ultimate slots horizontally and fix card inventory

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -1758,14 +1758,17 @@ body.page-characters::-webkit-scrollbar {
 }
 
 .card-inventory-panel {
-  background: linear-gradient(135deg, rgba(20, 20, 25, 0.98) 0%, rgba(30, 25, 20, 0.98) 100%);
-  border: 2px solid rgba(217, 179, 98, 0.3);
-  border-radius: 12px;
-  padding: 30px;
-  max-width: 90%;
-  max-height: 90%;
+  background-image: url('../assets/ui/infoframe.png');
+  background-size: 100% 100%;
+  background-repeat: no-repeat;
+  background-position: center;
+  padding: 40px;
+  width: 700px;
+  min-height: 500px;
+  max-height: 85vh;
   overflow-y: auto;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
 }
 
 .card-inventory-title {
@@ -1825,14 +1828,15 @@ body.page-characters::-webkit-scrollbar {
   position: absolute;
   bottom: 50px;
   right: 30px;
-  width: 200px;
-  height: 200px;
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
   z-index: 15;
 }
 
 .jutsu-slot,
 .ultimate-slot {
-  position: absolute;
+  position: relative;
   width: 70px;
   height: 70px;
   background: transparent;
@@ -1866,57 +1870,16 @@ body.page-characters::-webkit-scrollbar {
   filter: drop-shadow(0 2px 4px rgba(0,0,0,0.5));
 }
 
-/* Circular arrangement - 4 slots around a circle */
-/* Top slot (jutsu1) */
-.jutsu-slot[data-slot="jutsu1"] {
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-}
-
-/* Right slot (jutsu2) */
-.jutsu-slot[data-slot="jutsu2"] {
-  top: 50%;
-  right: 0;
-  transform: translateY(-50%);
-}
-
-/* Bottom slot (jutsu3) */
-.jutsu-slot[data-slot="jutsu3"] {
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
-}
-
-/* Left/Center slot (ultimate) - larger */
-.ultimate-slot[data-slot="ultimate"] {
-  top: 50%;
-  left: 0;
-  transform: translateY(-50%);
-  width: 90px;
-  height: 90px;
+/* Ultimate slot slightly larger */
+.ultimate-slot {
+  width: 80px;
+  height: 80px;
 }
 
 .jutsu-slot:hover,
 .ultimate-slot:hover {
   transform: scale(1.15);
   filter: brightness(1.2) drop-shadow(0 4px 8px rgba(217, 179, 98, 0.4));
-}
-
-.jutsu-slot[data-slot="jutsu1"]:hover {
-  transform: translateX(-50%) scale(1.15);
-}
-
-.jutsu-slot[data-slot="jutsu2"]:hover {
-  transform: translateY(-50%) scale(1.15);
-}
-
-.jutsu-slot[data-slot="jutsu3"]:hover {
-  transform: translateX(-50%) scale(1.15);
-}
-
-.ultimate-slot[data-slot="ultimate"]:hover {
-  transform: translateY(-50%) scale(1.15);
 }
 
 .jutsu-slot:active,

--- a/js/characters.js
+++ b/js/characters.js
@@ -2038,12 +2038,15 @@
     });
   }
 
-  // Delegate click handler for equipment slots
+  // Delegate click handler for equipment slots AND jutsu/ultimate slots
   document.addEventListener('click', (e) => {
     const equipmentSlot = e.target.closest('.equipment-slot');
-    if (equipmentSlot) {
+    const jutsuSlot = e.target.closest('.jutsu-slot');
+    const ultimateSlot = e.target.closest('.ultimate-slot');
+
+    if (equipmentSlot || jutsuSlot || ultimateSlot) {
       e.preventDefault();
-      openCardInventory(equipmentSlot);
+      openCardInventory(equipmentSlot || jutsuSlot || ultimateSlot);
     }
   });
 


### PR DESCRIPTION
- Change jutsu slots from circular to horizontal layout
- Use flexbox with row direction and gap for horizontal alignment
- Update card inventory panel to use infoframe.png background
- Add click handlers to jutsu/ultimate slots to open card inventory
- Equipment slots, jutsu slots, and ultimate slot all open same inventory modal
- Ultimate slot slightly larger (80px vs 70px for jutsu)