### PR TITLE
Enable jutsu equipment slot interactions

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -490,6 +490,7 @@ body.page-characters::-webkit-scrollbar {
   justify-content: center;
   border-radius: 8px;
   overflow: hidden;
+  cursor: pointer;
 }
 .equipment-slot img {
   width: 100%;
@@ -1827,7 +1828,7 @@ body.page-characters::-webkit-scrollbar {
 /* ========== Jutsu/Ultimate Slots (Inside Character Modal) ========== */
 .jutsu-slots-container {
   position: absolute;
-  bottom: 50px;
+  bottom: 125px;
   right: 30px;
   display: flex;
   flex-direction: row;

--- a/js/characters.js
+++ b/js/characters.js
@@ -311,6 +311,9 @@
     if (typeof window.renderJutsuSlots === 'function') {
       window.renderJutsuSlots(uid);
     }
+    if (typeof window.refreshJutsuEquipmentBindings === 'function') {
+      window.refreshJutsuEquipmentBindings();
+    }
 
     showModal();
   }
@@ -1940,6 +1943,40 @@
     pendingCardToEquip = null;
   }
 
+  function handleSlotClick(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    openCardInventory(event.currentTarget);
+  }
+
+  function handleSlotKeydown(event) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      event.stopPropagation();
+      openCardInventory(event.currentTarget);
+    }
+  }
+
+  function refreshSlotBindings() {
+    const slots = document.querySelectorAll('.equipment-slot, .tools-equipment-slot, .jutsu-slot, .ultimate-slot');
+    slots.forEach(slot => {
+      if (slot.dataset.jutsuSlotBound === 'true') return;
+
+      slot.dataset.jutsuSlotBound = 'true';
+      slot.addEventListener('click', handleSlotClick);
+      slot.addEventListener('keydown', handleSlotKeydown);
+
+      const isNativeButton = slot.tagName.toLowerCase() === 'button';
+
+      if (!slot.hasAttribute('role') && !isNativeButton) {
+        slot.setAttribute('role', 'button');
+      }
+      if (!slot.hasAttribute('tabindex') && !isNativeButton) {
+        slot.setAttribute('tabindex', '0');
+      }
+    });
+  }
+
   // Open card inventory modal
   function openCardInventory(equipmentSlot) {
     const charModal = document.getElementById('char-modal');
@@ -2045,7 +2082,7 @@
 
   // Delegate click handler for equipment slots AND jutsu/ultimate slots
   document.addEventListener('click', (e) => {
-    const equipmentSlot = e.target.closest('.equipment-slot');
+    const equipmentSlot = e.target.closest('.equipment-slot, .tools-equipment-slot');
     const jutsuSlot = e.target.closest('.jutsu-slot');
     const ultimateSlot = e.target.closest('.ultimate-slot');
 
@@ -2069,9 +2106,11 @@
 
   // Expose function to render jutsu slots when character modal opens
   window.renderJutsuSlots = renderJutsuSlots;
+  window.refreshJutsuEquipmentBindings = refreshSlotBindings;
 
   // Load jutsu cards on init
   loadJutsuCards();
+  refreshSlotBindings();
 
   console.log('[Jutsu Equipment] Initialized successfully');
 })();


### PR DESCRIPTION
## Summary
- ensure all equipment slot variants (including Tools tab slots) open the jutsu card inventory when clicked
- keep keyboard and mouse bindings refreshed for equipment, jutsu, and ultimate slots in the character modal
- retain updated jutsu slot container positioning and slot interactivity cues

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947973d34848325895cb352fbafd0a2)