### PR TITLE
Implement team background and add fusion paths for Gaara, Minato, and…

### DIFF
--- a/css/background.css
+++ b/css/background.css
@@ -52,6 +52,11 @@
   filter: brightness(0.95);
 }
 
+.page-teams #team-bg {
+  background: url("../assets/teams/teamsbackground.png") center top / 110% auto no-repeat;
+  filter: brightness(0.95);
+}
+
 /* ==========================================
    HUD & Button Layout (PERFECT CIRCLES)
    ========================================== */

--- a/data/fusions.json
+++ b/data/fusions.json
@@ -509,16 +509,70 @@
       }
     },
     {
-      "id": "kazekage_protection",
-      "name": "Kazekage's Protection",
-      "description": "Protect those precious to you",
+      "id": "gaara_step1",
+      "name": "Sand Demon's Awakening",
+      "description": "Begin to control the sand within",
+      "fusionPath": "gaara_legacy",
+      "stepNumber": 1,
       "requirements": {
-        "unit1": "gaara_173",
-        "unit2": "gaara_050",
+        "unit1": "gaara_185",
+        "unit2": "temari_163",
+        "minLevel": 40,
+        "materials": {
+          "ryo": 50000,
+          "scrolls": 5
+        }
+      },
+      "result": {
+        "characterId": "gaara_050",
+        "tier": "1S",
+        "level": 1,
+        "bonusStats": {
+          "hp": 300,
+          "atk": 140,
+          "def": 80
+        }
+      }
+    },
+    {
+      "id": "gaara_step2",
+      "name": "Ultimate Defense",
+      "description": "Master the absolute defense",
+      "fusionPath": "gaara_legacy",
+      "stepNumber": 2,
+      "requirements": {
+        "unit1": "gaara_050",
+        "unit2": "gaara_173",
         "minLevel": 50,
         "materials": {
-          "ryo": 70000,
-          "scrolls": 7
+          "ryo": 75000,
+          "scrolls": 8
+        }
+      },
+      "result": {
+        "characterId": "gaara_267",
+        "tier": "1S",
+        "level": 1,
+        "bonusStats": {
+          "hp": 400,
+          "atk": 170,
+          "def": 100
+        }
+      }
+    },
+    {
+      "id": "gaara_step3",
+      "name": "Kazekage's Burden",
+      "description": "Accept the weight of leadership",
+      "fusionPath": "gaara_legacy",
+      "stepNumber": 3,
+      "requirements": {
+        "unit1": "gaara_267",
+        "unit2": "gaara_185",
+        "minLevel": 60,
+        "materials": {
+          "ryo": 100000,
+          "scrolls": 10
         }
       },
       "result": {
@@ -526,9 +580,243 @@
         "tier": "1S",
         "level": 1,
         "bonusStats": {
-          "hp": 450,
+          "hp": 500,
+          "atk": 200,
+          "def": 120
+        }
+      }
+    },
+    {
+      "id": "gaara_step4",
+      "name": "Bonds of Sand",
+      "description": "Protect all who matter most",
+      "fusionPath": "gaara_legacy",
+      "stepNumber": 4,
+      "requirements": {
+        "unit1": "gaara_283",
+        "unit2": "gaara_173",
+        "minLevel": 70,
+        "materials": {
+          "ryo": 150000,
+          "scrolls": 15
+        }
+      },
+      "result": {
+        "characterId": "gaara_436",
+        "tier": "1S",
+        "level": 1,
+        "bonusStats": {
+          "hp": 700,
+          "atk": 280,
+          "def": 160
+        }
+      }
+    },
+    {
+      "id": "minato_step1",
+      "name": "Yellow Flash Rises",
+      "description": "Earn the legendary title",
+      "fusionPath": "minato_legacy",
+      "stepNumber": 1,
+      "requirements": {
+        "unit1": "minato_250",
+        "unit2": "kushina_231",
+        "minLevel": 40,
+        "materials": {
+          "ryo": 50000,
+          "scrolls": 5
+        }
+      },
+      "result": {
+        "characterId": "minato_229",
+        "tier": "1S",
+        "level": 1,
+        "bonusStats": {
+          "hp": 300,
           "atk": 160,
+          "def": 60
+        }
+      }
+    },
+    {
+      "id": "minato_step2",
+      "name": "Rasengan Creator",
+      "description": "Develop the signature technique",
+      "fusionPath": "minato_legacy",
+      "stepNumber": 2,
+      "requirements": {
+        "unit1": "minato_229",
+        "unit2": "jiraiya_072",
+        "minLevel": 50,
+        "materials": {
+          "ryo": 75000,
+          "scrolls": 8
+        }
+      },
+      "result": {
+        "characterId": "minato_409",
+        "tier": "1S",
+        "level": 1,
+        "bonusStats": {
+          "hp": 400,
+          "atk": 190,
+          "def": 80
+        }
+      }
+    },
+    {
+      "id": "minato_step3",
+      "name": "Fourth Hokage",
+      "description": "Become the village's leader",
+      "fusionPath": "minato_legacy",
+      "stepNumber": 3,
+      "requirements": {
+        "unit1": "minato_409",
+        "unit2": "minato_250",
+        "minLevel": 60,
+        "materials": {
+          "ryo": 100000,
+          "scrolls": 10
+        }
+      },
+      "result": {
+        "characterId": "minato_410",
+        "tier": "1S",
+        "level": 1,
+        "bonusStats": {
+          "hp": 500,
+          "atk": 220,
           "def": 100
+        }
+      }
+    },
+    {
+      "id": "minato_step4",
+      "name": "Heroic Sacrifice",
+      "description": "Ultimate speed and power unleashed",
+      "fusionPath": "minato_legacy",
+      "stepNumber": 4,
+      "requirements": {
+        "unit1": "minato_410",
+        "unit2": "kushina_231",
+        "minLevel": 70,
+        "materials": {
+          "ryo": 150000,
+          "scrolls": 15
+        }
+      },
+      "result": {
+        "characterId": "minato_459",
+        "tier": "1S",
+        "level": 1,
+        "bonusStats": {
+          "hp": 700,
+          "atk": 320,
+          "def": 140
+        }
+      }
+    },
+    {
+      "id": "itachi_step1",
+      "name": "Uchiha Prodigy",
+      "description": "Young genius of the Uchiha clan",
+      "fusionPath": "itachi_legacy",
+      "stepNumber": 1,
+      "requirements": {
+        "unit1": "itachi_088",
+        "unit2": "sasuke_175",
+        "minLevel": 40,
+        "materials": {
+          "ryo": 50000,
+          "scrolls": 5
+        }
+      },
+      "result": {
+        "characterId": "itachi_208",
+        "tier": "1S",
+        "level": 1,
+        "bonusStats": {
+          "hp": 280,
+          "atk": 170,
+          "def": 60
+        }
+      }
+    },
+    {
+      "id": "itachi_step2",
+      "name": "Mangekyo Awakened",
+      "description": "Unlock the Mangekyo Sharingan",
+      "fusionPath": "itachi_legacy",
+      "stepNumber": 2,
+      "requirements": {
+        "unit1": "itachi_208",
+        "unit2": "itachi_088",
+        "minLevel": 50,
+        "materials": {
+          "ryo": 75000,
+          "scrolls": 8
+        }
+      },
+      "result": {
+        "characterId": "itachi_210",
+        "tier": "1S",
+        "level": 1,
+        "bonusStats": {
+          "hp": 380,
+          "atk": 200,
+          "def": 75
+        }
+      }
+    },
+    {
+      "id": "itachi_step3",
+      "name": "Akatsuki's Shadow",
+      "description": "Walk the path of darkness for the light",
+      "fusionPath": "itachi_legacy",
+      "stepNumber": 3,
+      "requirements": {
+        "unit1": "itachi_210",
+        "unit2": "kisame_090",
+        "minLevel": 60,
+        "materials": {
+          "ryo": 100000,
+          "scrolls": 10
+        }
+      },
+      "result": {
+        "characterId": "itachi_308",
+        "tier": "1S",
+        "level": 1,
+        "bonusStats": {
+          "hp": 480,
+          "atk": 230,
+          "def": 90
+        }
+      }
+    },
+    {
+      "id": "itachi_step4",
+      "name": "Truth Revealed",
+      "description": "The ultimate sacrifice for peace",
+      "fusionPath": "itachi_legacy",
+      "stepNumber": 4,
+      "requirements": {
+        "unit1": "itachi_308",
+        "unit2": "sasuke_175",
+        "minLevel": 70,
+        "materials": {
+          "ryo": 150000,
+          "scrolls": 15
+        }
+      },
+      "result": {
+        "characterId": "itachi_387",
+        "tier": "1S",
+        "level": 1,
+        "bonusStats": {
+          "hp": 680,
+          "atk": 310,
+          "def": 130
         }
       }
     }
@@ -550,6 +838,18 @@
       "bonusPerStep": 0.05
     },
     "sasuke_legacy": {
+      "maxSteps": 4,
+      "bonusPerStep": 0.05
+    },
+    "gaara_legacy": {
+      "maxSteps": 4,
+      "bonusPerStep": 0.05
+    },
+    "minato_legacy": {
+      "maxSteps": 4,
+      "bonusPerStep": 0.05
+    },
+    "itachi_legacy": {
       "maxSteps": 4,
       "bonusPerStep": 0.05
     }


### PR DESCRIPTION
… Itachi

Background Changes:
- Added team background CSS for .page-teams #team-bg
- Uses assets/teams/teamsbackground.png with 110% scale and brightness filter

Fusion System Additions:
- Gaara Legacy Path (4 steps):
  * Sand Demon's Awakening → Ultimate Defense → Kazekage's Burden → Bonds of Sand
  * Progression: gaara_185 → gaara_050 → gaara_267 → gaara_283 → gaara_436
  * Uses Temari as fusion material for sibling bond theme

- Minato Legacy Path (4 steps):
  * Yellow Flash Rises → Rasengan Creator → Fourth Hokage → Heroic Sacrifice
  * Progression: minato_250 → minato_229 → minato_409 → minato_410 → minato_459
  * Uses Kushina and Jiraiya as fusion materials for mentor/love themes

- Itachi Legacy Path (4 steps):
  * Uchiha Prodigy → Mangekyo Awakened → Akatsuki's Shadow → Truth Revealed
  * Progression: itachi_088 → itachi_208 → itachi_210 → itachi_308 → itachi_387
  * Uses Sasuke and Kisame as fusion materials for brother/partner themes

Path Configuration:
- All three paths grant 5% per step (20% total at step 4)
- Consistent with existing Naruto/Sasuke legacy bonus structure
- Progressive stat bonuses that increase each step
- All fusions return base tier (1S) for evolution gameplay