### PR TITLE
Fix level holder and button sizing issues

### DIFF
--- a/css/characters.css
+++ b/css/characters.css
@@ -545,22 +545,31 @@ body.page-characters::-webkit-scrollbar {
   font-size: 15px;
 }
 .level-badge {
+  position: relative;
   background-color: transparent;
+  border: none;
+  padding: 2px 10px;
+  color: #e8e3d1;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.level-badge::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 240px;
+  height: 60px;
   background-image: url('../assets/ui/levelholder.png');
   background-size: contain;
   background-position: center;
   background-repeat: no-repeat;
-  border: none;
-  padding: 2px 6px;
-  color: #e8e3d1;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
-  min-width: 240px;
-  min-height: 60px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  font-size: 1.2rem;
+  z-index: -1;
 }
 .level-badge .lv { margin-right: 3px; color: #fff; }
 .level-badge .max { color: var(--gold); font-weight: 600; }
@@ -608,8 +617,8 @@ body.page-characters::-webkit-scrollbar {
   background-repeat: no-repeat;
   border: none;
   color: transparent;
-  min-width: 360px;
-  min-height: 120px;
+  min-width: 120px;
+  min-height: 40px;
 }
 .btn-awaken:disabled {
   background-image: url('../assets/ui/locked_awaken_btn.png');


### PR DESCRIPTION
- Changed level holder to use ::before pseudo-element for 3x bigger background image
- Kept text size normal while background image is 240px x 60px
- Reverted awakening button from 360px back to 120px (normal size)
- Button files already using correct assets/ui/ paths
- Improved spacing by using inline-flex for level badge container